### PR TITLE
fix building of shared libraries on Cygwin/MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,18 @@ AC_PROG_INSTALL
 dnl Our "make distcheck" needs egrep.
 AC_PROG_EGREP
 dnl Configure libtool.
-LT_INIT
+LT_INIT([win32-dll])
+
+AC_CANONICAL_HOST
+dnl libtool requires "-no-undefined" for win32 dll
+AC_SUBST(CDD_LDFLAGS)
+case $host_os in
+    *cygwin*|*mingw*)
+    if test x"$enable_shared" = "xyes"; then
+        CDD_LDFLAGS="$CDD_LDFLAGS -no-undefined"
+    fi
+;;
+esac
 
 dnl Look for gmp. But do not prepend -lgmp to LIBS as we do not want to link everything against gmp.
 AC_CHECK_LIB([gmp], [__gmpz_init], [true])

--- a/lib-src/Makefile.am
+++ b/lib-src/Makefile.am
@@ -10,7 +10,7 @@ cddproj.c \
 setoper.c
 libcdd_la_CPPFLAGS = -UGMPRATIONAL
 
-AM_LDFLAGS = -version-info $(libcdd_version_info)
+AM_LDFLAGS = -version-info $(libcdd_version_info) $(CDD_LDFLAGS)
 
 include_HEADERS = \
 cdd.h \

--- a/lib-src/Makefile.gmp.am
+++ b/lib-src/Makefile.gmp.am
@@ -9,6 +9,7 @@ cddtypes_f.h
 
 libcddgmp_la_SOURCES = $(libcdd_la_SOURCES)
 libcddgmp_la_CPPFLAGS = -DGMPRATIONAL
+libcddgmp_la_LDFLAGS = -lgmp
 # do not ship generated source files
 nodist_libcddgmp_la_SOURCES = \
 cddcore_f.c \


### PR DESCRIPTION
Generally what this requires is that there are no undefined symbols at link time, even for shared libs.

Fixes #8.