### PR TITLE
Use a portable random number generator

### DIFF
--- a/lib-src/Makefile.am
+++ b/lib-src/Makefile.am
@@ -16,6 +16,7 @@ include_HEADERS = \
 cdd.h \
 cddmp.h \
 cddtypes.h \
-setoper.h
+setoper.h \
+splitmix64.h
 
 include ./Makefile.gmp.am

--- a/lib-src/cddcore.c
+++ b/lib-src/cddcore.c
@@ -12,6 +12,7 @@
 
 #include "setoper.h"  /* set operation library header (Ver. June 1, 2000 or later) */
 #include "cdd.h"
+#include "splitmix64.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -1856,12 +1857,12 @@ void dd_QuickSort(dd_rowindex OV, long p, long r, dd_Amatrix A, long dmax)
 void dd_RandomPermutation(dd_rowindex OV, long t, unsigned int seed)
 {
   long k,j,ovj;
-  double u,xk,r,rand_max=(double) RAND_MAX;
+  double u,xk,r,rand_max=(double) UINT64_MAX;
   dd_boolean localdebug=dd_FALSE;
 
-  srand(seed);
+  srand_splitmix64(seed);
   for (j=t; j>1 ; j--) {
-    r=rand();
+    r=rand_splitmix64();
     u=r/rand_max;
     xk=(double)(j*u +1);
     k=(long)xk;

--- a/lib-src/cddlp.c
+++ b/lib-src/cddlp.c
@@ -13,6 +13,7 @@
 
 #include "setoper.h"  /* set operation library header (Ver. May 18, 2000 or later) */
 #include "cdd.h"
+#include "splitmix64.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -1752,12 +1753,12 @@ the LP.
 void dd_RandomPermutation2(dd_rowindex OV,long t,unsigned int seed)
 {
   long k,j,ovj;
-  double u,xk,r,rand_max=(double) RAND_MAX;
+  double u,xk,r,rand_max=(double) UINT64_MAX;
   int localdebug=dd_FALSE;
 
-  srand(seed);
+  srand_splitmix64(seed);
   for (j=t; j>1 ; j--) {
-    r=rand();
+    r=rand_splitmix64();
     u=r/rand_max;
     xk=(double)(j*u +1);
     k=(long)xk;

--- a/lib-src/splitmix64.h
+++ b/lib-src/splitmix64.h
@@ -1,0 +1,27 @@
+/* 
+ * A fast portable random number generator.
+ *
+ * Adapted version of splitmix64.c originally published by Sebastiano
+ * Vigna to the public domain.
+ * http://xoroshiro.di.unimi.it/splitmix64.c
+*/
+
+#ifndef __SPLITMIX64_H
+#define __SPLITMIX64_H
+
+#include <stdint.h>
+
+static uint64_t x; /* The state can be seeded with any value. */
+
+void srand_splitmix64(uint64_t seed) {
+	x = seed;
+}
+
+uint64_t rand_splitmix64() {
+	uint64_t z = (x += 0x9e3779b97f4a7c15);
+	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+	z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+	return z ^ (z >> 31);
+}
+
+#endif // __SPLITMIX64_H

--- a/lib-src/splitmix64.h
+++ b/lib-src/splitmix64.h
@@ -13,11 +13,11 @@
 
 static uint64_t x; /* The state can be seeded with any value. */
 
-void srand_splitmix64(uint64_t seed) {
+static void srand_splitmix64(uint64_t seed) {
 	x = seed;
 }
 
-uint64_t rand_splitmix64() {
+static uint64_t rand_splitmix64() {
 	uint64_t z = (x += 0x9e3779b97f4a7c15);
 	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
 	z = (z ^ (z >> 27)) * 0x94d049bb133111eb;


### PR DESCRIPTION
Resolves #5.

SageMath needs to work around the fact that cddlib uses pseudo-random numbers.
The problem is that srand()/rand() are not portable, i.e., srand() with the
same seed produces different rand() outputs on different platforms. So in
particular putting the same data into cddlib produces different outputs on
Solaris/Linux/OSX.