### PR TITLE
Allow building against MPIR instead of GMP.

### DIFF
--- a/lib-src/cddmp.h
+++ b/lib-src/cddmp.h
@@ -28,7 +28,11 @@
 /**********************************/
 
 #if defined GMPRATIONAL
- #include "gmp.h"
+ #if defined MPIR
+  #include "mpir.h"
+ #else
+  #include "gmp.h"
+ #endif
  #define dd_ARITHMETIC "GMP rational"
  #define dd_init(a)              mpq_init(a)     
  #define dd_clear(a)             mpq_clear(a)     
@@ -48,7 +52,11 @@
     /* returns nonzero if equal.  much faster than mpq_cmp. */
  #define dd_get_d(a)             mpq_get_d(a)     
 #elif defined GMPFLOAT
- #include "gmp.h"
+ #if defined MPIR
+  #include "mpir.h"
+ #else
+  #include "gmp.h"
+ #endif
  #define dd_ARITHMETIC "GMP float"
  #define dd_init(a)              mpf_init(a)     
  #define dd_clear(a)             mpf_clear(a)     


### PR DESCRIPTION
This allows cddlib to be compiled more easily with MSVC (e.g. for the pycddlib Python wrapper, see https://github.com/mcmtroffaes/pycddlib). The patch will simply use MPIR instead of GMP whenever the "MPIR" symbol is defined by the compiler.

There's no configure support for MPIR, since I imagine that only scenario where you want to compile cddlib with MSVC wouldn't be using autotools anyway.