### PR TITLE
Ensure pointers are properly initialized even on zero length allocation.

### DIFF
--- a/lib-src/cddcore.c
+++ b/lib-src/cddcore.c
@@ -693,7 +693,7 @@ void dd_InitializeArow(dd_colrange d,dd_Arow *a)
 {
   dd_colrange j;
 
-  if (d>0) *a=(mytype*) calloc(d,sizeof(mytype));
+  *a=(mytype*) calloc(d,sizeof(mytype));
   for (j = 0; j < d; j++) {
       dd_init((*a)[j]);
   }
@@ -703,7 +703,7 @@ void dd_InitializeAmatrix(dd_rowrange m,dd_colrange d,dd_Amatrix *A)
 {
   dd_rowrange i;
 
-  if (m>0) (*A)=(mytype**) calloc(m,sizeof(mytype*));
+  (*A)=(mytype**) calloc(m,sizeof(mytype*));
   for (i = 0; i < m; i++) {
     dd_InitializeArow(d,&((*A)[i]));
   }


### PR DESCRIPTION
This avoids segfaults later when these pointers are freed. The segfaults were originally reported here https://github.com/mcmtroffaes/pycddlib/issues/25 by @JoostvanPinxten who tried to create a Polyhedron from an empty matrix. I've tested the patch and it fixed the reported problem.