### PR TITLE
Remove unsed variable jmin

### DIFF
--- a/lib-src/cddcore.c
+++ b/lib-src/cddcore.c
@@ -581,20 +581,20 @@ void dd_FreePolyhedra(dd_PolyhedraPtr poly)
 
 void dd_Normalize(dd_colrange d_size, mytype *V)
 {
-  long j,jmin=0;
+  long j;
   mytype temp,min;
   dd_boolean nonzerofound=dd_FALSE;
 
   if (d_size>0){
     dd_init(min);  dd_init(temp);
-    dd_abs(min,V[0]);  jmin=0; /* set the minmizer to 0 */
+    dd_abs(min,V[0]); /* set the minmizer to 0 */
     if (dd_Positive(min)) nonzerofound=dd_TRUE;
     for (j = 1; j < d_size; j++) {
       dd_abs(temp,V[j]);
       if (dd_Positive(temp)){
         if (!nonzerofound || dd_Smaller(temp,min)){
           nonzerofound=dd_TRUE;
-          dd_set(min, temp);  jmin=j;
+          dd_set(min, temp);
         }
       }
     }


### PR DESCRIPTION
It seems this variable is computing the argmin but it is never used.
It was removed in my fork and it didn't affect cddlib: https://github.com/JuliaPolyhedra/cddlib/commit/19ce74e2b928fdea4d107901b2b1423b5b4e074e