### PR TITLE
Fix typo in doc of MatrixCanonicalizeLinearity

### DIFF
--- a/doc/cddlibman.tex
+++ b/doc/cddlibman.tex
@@ -560,7 +560,7 @@ because it may generate two different representations of the same
 polyhedron.  In the future, this function is expected to be correctly
 implemented. 
 
-\item[{\tt dd\_boolean dd\_MatrixCanonicalizeLinearity(matrixP, impl\_linset, newpos. err)}]:\\
+\item[{\tt dd\_boolean dd\_MatrixCanonicalizeLinearity(matrixP, impl\_linset, newpos, err)}]:\\
 It does only the first half of {\tt dd\_boolean dd\_MatrixCanonicalize}, namely, it detects all
 implicit linearities and puts a maximally independent linearities
 at the top of the matrix.  For example, this function can be 


### PR DESCRIPTION
Backported from https://github.com/JuliaPolyhedra/cddlib/commit/616f01f11e89e80b57fb23d5036b39b6d7feb3d9