### PR TITLE
Install headers to $(PACKAGE) subdirectory

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,1 +1,0 @@
-ChangeLog

--- a/NEWS
+++ b/NEWS
@@ -1,1 +1,0 @@
-HISTORY

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.md

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ dnl Set to c:r+1:a if the interface is unchanged.
 AC_SUBST([libcdd_version_info], [0:0:0])
 
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([1.14.1 foreign])
+AM_INIT_AUTOMAKE([1.14.1 foreign tar-ustar])
 
 dnl Find C compiler.
 AC_PROG_CC

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ dnl Set to c:r+1:a if the interface is unchanged.
 AC_SUBST([libcdd_version_info], [0:0:0])
 
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([1.14.1])
+AM_INIT_AUTOMAKE([1.14.1 foreign])
 
 dnl Find C compiler.
 AC_PROG_CC

--- a/lib-src/Makefile.am
+++ b/lib-src/Makefile.am
@@ -12,7 +12,7 @@ libcdd_la_CPPFLAGS = -UGMPRATIONAL
 
 AM_LDFLAGS = -version-info $(libcdd_version_info) $(CDD_LDFLAGS)
 
-include_HEADERS = \
+pkginclude_HEADERS = \
 cdd.h \
 cddmp.h \
 cddtypes.h \

--- a/lib-src/Makefile.gmp.am
+++ b/lib-src/Makefile.gmp.am
@@ -2,7 +2,7 @@ if GMP
 
 lib_LTLIBRARIES += libcddgmp.la
 
-include_HEADERS += \
+pkginclude_HEADERS += \
 cdd_f.h \
 cddmp_f.h \
 cddtypes_f.h

--- a/src/adjacency.c
+++ b/src/adjacency.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/allfaces.c
+++ b/src/allfaces.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/fourier.c
+++ b/src/fourier.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/lcdd.c
+++ b/src/lcdd.c
@@ -31,8 +31,8 @@
     lcdd < filein
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/projection.c
+++ b/src/projection.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/redcheck.c
+++ b/src/redcheck.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/redexter.c
+++ b/src/redexter.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/redundancies.c
+++ b/src/redundancies.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/redundancies_clarkson.c
+++ b/src/redundancies_clarkson.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/scdd.c
+++ b/src/scdd.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/testcdd1.c
+++ b/src/testcdd1.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/testcdd2.c
+++ b/src/testcdd2.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/testlp1.c
+++ b/src/testlp1.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/testlp2.c
+++ b/src/testlp2.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/testlp3.c
+++ b/src/testlp3.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/testshoot.c
+++ b/src/testshoot.c
@@ -19,8 +19,8 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include <setoper.h>
-#include <cdd.h>
+#include "setoper.h"
+#include "cdd.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
I agree with the approach that @jengelh used here. There's no way to please everyone -- using `cdd` as the directory name is still going to break everything that's looking in the upstream location, and Fedora has chosen the `cddlib` subdirectory already, so it's not even clear that choosing `cdd` would cause fewer problems. Given that, using the built-in automake support for `pkginclude_HEADERS` makes the most sense.

There is a question of what to do with the `src/*.c` example programs down the road (see the commit messages), but I haven't made anything worse in this regard.
