### PR TITLE
fix version info for libcddgmp

### DIFF
--- a/lib-src/Makefile.gmp.am
+++ b/lib-src/Makefile.gmp.am
@@ -9,7 +9,7 @@ cddtypes_f.h
 
 libcddgmp_la_SOURCES = $(libcdd_la_SOURCES)
 libcddgmp_la_CPPFLAGS = -DGMPRATIONAL
-libcddgmp_la_LDFLAGS = -lgmp
+libcddgmp_la_LDFLAGS = $(AM_LDFLAGS) -lgmp
 # do not ship generated source files
 nodist_libcddgmp_la_SOURCES = \
 cddcore_f.c \


### PR DESCRIPTION
without this,  the version of libcddgmp always stays 0.0.0