### PR TITLE
Avoid mixing -lcdd and -lcddgmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 ### Autotools ###
 # http://www.gnu.org/software/automake
 
-cddlib.pc
+/cddgmp.pc
+/cddlib.pc
 Makefile.in
 /ar-lib
 /mdate-sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,3 +15,6 @@ distcheck-hook:
 
 pkgconfigdir       = $(libdir)/pkgconfig
 pkgconfig_DATA     = cddlib.pc
+if GMP
+pkgconfig_DATA    += cddgmp.pc
+endif

--- a/cddgmp.pc.in
+++ b/cddgmp.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@prefix@/include
+
+Name: @PACKAGE_NAME@
+Description: C library implementing Double Description Method (generating vertices, etc. of polyhedra) using GMP rationals
+Version: @PACKAGE_VERSION@
+Libs: @CDD_LDFLAGS@ -L${libdir} -lcddgmp
+Cflags: -I${includedir} -DGMPRATIONAL

--- a/cddgmp.pc.in
+++ b/cddgmp.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@prefix@/include
+includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 Description: C library implementing Double Description Method (generating vertices, etc. of polyhedra) using GMP rationals

--- a/cddlib.pc.in
+++ b/cddlib.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@prefix@/include
+includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 Description: C library implementing Double Description Method (generating vertices, etc. of polyhedra)

--- a/cddlib.pc.in
+++ b/cddlib.pc.in
@@ -6,5 +6,5 @@ includedir=@prefix@/include
 Name: @PACKAGE_NAME@
 Description: C library implementing Double Description Method (generating vertices, etc. of polyhedra)
 Version: @PACKAGE_VERSION@
-Libs: @CDD_LDFLAGS@ -L${libdir} @CDD_LIBS@
-Cflags: -I${includedir}
+Libs: @CDD_LDFLAGS@ -L${libdir} -lcdd
+Cflags: -I${includedir} -UGMPRATIONAL

--- a/configure.ac
+++ b/configure.ac
@@ -42,8 +42,6 @@ AC_CHECK_HEADER(gmp.h, [
 
 dnl We do not build the gmp enabled library if we don't have gmp.
 AM_CONDITIONAL([GMP], [test "x$ac_cv_lib_gmp___gmpz_init" = "xyes"])
-AS_IF([test "x$ac_cv_lib_gmp___gmpz_init" = "xyes"], [CDD_LIBS="-lcdd -lcddgmp"], [CDD_LIBS="-lcdd"])
-AC_SUBST(CDD_LIBS)
 
 dnl Check for latex to build the documentation dvi
 AC_CHECK_PROGS([latex], [latex])
@@ -61,5 +59,5 @@ dnl Check for dvips to build the documentation ps
 AC_CHECK_PROGS([dvips], [dvips])
 AM_CONDITIONAL([PS], [test "x$ac_cv_prog_dvips" != "x"])
 
-AC_CONFIG_FILES([doc/Makefile lib-src/Makefile src/Makefile Makefile cddlib.pc])
+AC_CONFIG_FILES([doc/Makefile lib-src/Makefile src/Makefile Makefile cddgmp.pc cddlib.pc])
 AC_OUTPUT


### PR DESCRIPTION
    Both libcdd.so and libcddgmp.so offer the same function names, but
    have very different ABIs. A third-party program wanting to use the
    GMP-enabled libcddgmp must not use the no-GMP libcdd. The pkgconfig
    file however specified both, and so the no-GMP library would be used
    during linking at all times.
    
    One possibility is to offer one .pc file per configuration, the other
    would be that CDD stops offering multiple libraries and settles on
    that `make install` delivers just one variant (either no-GMP or GMP,
    depending on user choice).
