### PR TITLE
Correct the ViaShooting functionality

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@
 * Julian Rüth
 * Matthias C. M. Troffaes
 * Michael Orlitzky
+* Mathieu Dutour Sikiric

--- a/lib-src/cddlp.c
+++ b/lib-src/cddlp.c
@@ -2945,6 +2945,7 @@ dd_rowset dd_RedundantRowsViaShooting(dd_MatrixPtr M, dd_ErrorType *error)  /* 0
           if (localdebug) fprintf(stderr, "The %ld th inequality is redundant for the subsystem and thus for the whole.\n", i);
           rowflag[i]=-1;
           set_addelem(redset, i);
+          irow--;  M1->rowsize=irow;
           i++;
         }
       } else {

--- a/news/issue45.rst
+++ b/news/issue45.rst
@@ -1,3 +1,7 @@
 **Fixed:**
 
 * Fix and error, where a non-redundant linearity could be considered redundant.
+
+**Fixed:**
+
+* Fix an optimization error in ViaShooting code so that the linear programs are now much smaller.


### PR DESCRIPTION
In the `dd_RedundantRowsViaShooting` function we test whether a ray is redundant or not by linear programming.
The operation before the check is `irow++;  M1->rowsize=irow;`. 
If the ray is effectively found to be redundant then the row can be actually removed from the linear program.
Thus the operation `irow--;  M1->rowsize=irow;` is added.

The resulting speed improvement is tremendous. If say we have 1000 defining inequality and 10 being non redundant then in the old code the last linear programming check has 1000 defining inequalities. With the new code, it never goes above 10.
