### PR TITLE
Ensure variable names of parameters in function declarations are present and consistent with definition.

### DIFF
--- a/lib-src/cdd.h
+++ b/lib-src/cdd.h
@@ -57,228 +57,228 @@ extern dd_boolean dd_choiceLexicoPivotQ;    /* whether to use the lexicographic 
 /* ---------- FUNCTIONS MEANT TO BE PUBLIC ---------- */
 
 /* basic matrix manipulations */
-void dd_InitializeArow(dd_colrange,dd_Arow *);
-void dd_InitializeAmatrix(dd_rowrange,dd_colrange,dd_Amatrix *);
-void dd_InitializeBmatrix(dd_colrange, dd_Bmatrix *);
-dd_SetFamilyPtr dd_CreateSetFamily(dd_bigrange,dd_bigrange);
-void dd_FreeSetFamily(dd_SetFamilyPtr);
-dd_MatrixPtr dd_CreateMatrix(dd_rowrange,dd_colrange);
-void dd_FreeAmatrix(dd_rowrange,dd_colrange,dd_Amatrix);
-void dd_FreeArow(dd_colrange, dd_Arow);
-void dd_FreeBmatrix(dd_colrange,dd_Bmatrix);
-void dd_FreeDDMemory(dd_PolyhedraPtr);
-void dd_FreePolyhedra(dd_PolyhedraPtr);
-void dd_FreeMatrix(dd_MatrixPtr);
-void dd_SetToIdentity(dd_colrange, dd_Bmatrix);
+void dd_InitializeArow(dd_colrange d,dd_Arow * a);
+void dd_InitializeAmatrix(dd_rowrange m,dd_colrange d,dd_Amatrix * A);
+void dd_InitializeBmatrix(dd_colrange d, dd_Bmatrix * B);
+dd_SetFamilyPtr dd_CreateSetFamily(dd_bigrange fsize,dd_bigrange ssize);
+void dd_FreeSetFamily(dd_SetFamilyPtr F);
+dd_MatrixPtr dd_CreateMatrix(dd_rowrange m_size,dd_colrange d_size);
+void dd_FreeAmatrix(dd_rowrange m,dd_colrange d,dd_Amatrix A);
+void dd_FreeArow(dd_colrange d, dd_Arow a);
+void dd_FreeBmatrix(dd_colrange d,dd_Bmatrix B);
+void dd_FreeDDMemory(dd_PolyhedraPtr poly);
+void dd_FreePolyhedra(dd_PolyhedraPtr poly);
+void dd_FreeMatrix(dd_MatrixPtr M);
+void dd_SetToIdentity(dd_colrange d_size, dd_Bmatrix T);
 
 /* sign recognitions */
-dd_boolean dd_Nonnegative(mytype);
-dd_boolean dd_Nonpositive(mytype);
-dd_boolean dd_Positive(mytype);
-dd_boolean dd_Negative(mytype);
-dd_boolean dd_EqualToZero(mytype);
-dd_boolean dd_Nonzero(mytype);
-dd_boolean dd_Equal(mytype,mytype);
-dd_boolean dd_Larger(mytype,mytype);
-dd_boolean dd_Smaller(mytype,mytype);
-void dd_abs(mytype, mytype);
-void dd_LinearComb(mytype, mytype, mytype, mytype, mytype);
-void dd_InnerProduct(mytype, dd_colrange, dd_Arow, dd_Arow);
+dd_boolean dd_Nonnegative(mytype val);
+dd_boolean dd_Nonpositive(mytype val);
+dd_boolean dd_Positive(mytype val);
+dd_boolean dd_Negative(mytype val);
+dd_boolean dd_EqualToZero(mytype val);
+dd_boolean dd_Nonzero(mytype val);
+dd_boolean dd_Equal(mytype val1,mytype val2);
+dd_boolean dd_Larger(mytype val1,mytype val2);
+dd_boolean dd_Smaller(mytype val1,mytype val2);
+void dd_abs(mytype absval, mytype val);
+void dd_LinearComb(mytype lc, mytype v1, mytype c1, mytype v2, mytype c2);
+void dd_InnerProduct(mytype prod, dd_colrange d, dd_Arow v1, dd_Arow v2);
 
 /* major cddlib operations */
-dd_MatrixPtr dd_CopyInput(dd_PolyhedraPtr);
-dd_MatrixPtr dd_CopyOutput(dd_PolyhedraPtr);
-dd_MatrixPtr dd_CopyInequalities(dd_PolyhedraPtr);
-dd_MatrixPtr dd_CopyGenerators(dd_PolyhedraPtr);
-dd_SetFamilyPtr dd_CopyIncidence(dd_PolyhedraPtr);
-dd_SetFamilyPtr dd_CopyAdjacency(dd_PolyhedraPtr);
-dd_SetFamilyPtr dd_CopyInputIncidence(dd_PolyhedraPtr);
-dd_SetFamilyPtr dd_CopyInputAdjacency(dd_PolyhedraPtr);
+dd_MatrixPtr dd_CopyInput(dd_PolyhedraPtr poly);
+dd_MatrixPtr dd_CopyOutput(dd_PolyhedraPtr poly);
+dd_MatrixPtr dd_CopyInequalities(dd_PolyhedraPtr poly);
+dd_MatrixPtr dd_CopyGenerators(dd_PolyhedraPtr poly);
+dd_SetFamilyPtr dd_CopyIncidence(dd_PolyhedraPtr poly);
+dd_SetFamilyPtr dd_CopyAdjacency(dd_PolyhedraPtr poly);
+dd_SetFamilyPtr dd_CopyInputIncidence(dd_PolyhedraPtr poly);
+dd_SetFamilyPtr dd_CopyInputAdjacency(dd_PolyhedraPtr poly);
 dd_boolean dd_DDFile2File(char *ifile, char *ofile, dd_ErrorType *err);
-dd_boolean dd_DDInputAppend(dd_PolyhedraPtr*, dd_MatrixPtr, dd_ErrorType*);
-dd_MatrixPtr dd_PolyFile2Matrix(FILE *f, dd_ErrorType *);
+dd_boolean dd_DDInputAppend(dd_PolyhedraPtr* poly, dd_MatrixPtr M, dd_ErrorType* err);
+dd_MatrixPtr dd_PolyFile2Matrix(FILE *f, dd_ErrorType * Error);
 
-dd_PolyhedraPtr dd_DDMatrix2Poly(dd_MatrixPtr, dd_ErrorType *);
-dd_PolyhedraPtr dd_DDMatrix2Poly2(dd_MatrixPtr, dd_RowOrderType, dd_ErrorType *);
-dd_boolean dd_Redundant(dd_MatrixPtr, dd_rowrange, dd_Arow, dd_ErrorType *);  /* 092 */
-dd_rowset dd_RedundantRows(dd_MatrixPtr, dd_ErrorType *);  /* 092 */
-dd_boolean dd_SRedundant(dd_MatrixPtr, dd_rowrange, dd_Arow, dd_ErrorType *);  /* 093a */
-dd_rowset dd_SRedundantRows(dd_MatrixPtr, dd_ErrorType *);  /* 093a */
-dd_rowset dd_RedundantRowsViaShooting(dd_MatrixPtr, dd_ErrorType *); /* 092 */
-dd_rowrange dd_RayShooting(dd_MatrixPtr, dd_Arow intpt, dd_Arow direction);  /* 092 */ 
+dd_PolyhedraPtr dd_DDMatrix2Poly(dd_MatrixPtr M, dd_ErrorType * err);
+dd_PolyhedraPtr dd_DDMatrix2Poly2(dd_MatrixPtr M, dd_RowOrderType horder, dd_ErrorType * err);
+dd_boolean dd_Redundant(dd_MatrixPtr M, dd_rowrange itest, dd_Arow certificate, dd_ErrorType * error);  /* 092 */
+dd_rowset dd_RedundantRows(dd_MatrixPtr M, dd_ErrorType * error);  /* 092 */
+dd_boolean dd_SRedundant(dd_MatrixPtr M, dd_rowrange itest, dd_Arow certificate, dd_ErrorType * error);  /* 093a */
+dd_rowset dd_SRedundantRows(dd_MatrixPtr M, dd_ErrorType * error);  /* 093a */
+dd_rowset dd_RedundantRowsViaShooting(dd_MatrixPtr M, dd_ErrorType * error); /* 092 */
+dd_rowrange dd_RayShooting(dd_MatrixPtr M, dd_Arow p, dd_Arow r);  /* 092 */ 
  /* 092, find the first inequality "hit" by a ray from an intpt.  */
-dd_boolean dd_ImplicitLinearity(dd_MatrixPtr, dd_rowrange, dd_Arow, dd_ErrorType *);  /* 092 */
-dd_rowset dd_ImplicitLinearityRows(dd_MatrixPtr, dd_ErrorType *);  /* 092  */
-int dd_FreeOfImplicitLinearity(dd_MatrixPtr, dd_Arow, dd_rowset *, dd_ErrorType *) ; /* 094 */
-dd_boolean dd_MatrixCanonicalizeLinearity(dd_MatrixPtr *, dd_rowset *,dd_rowindex *, dd_ErrorType *); /* 094 */
-dd_boolean dd_MatrixCanonicalize(dd_MatrixPtr *, dd_rowset *, dd_rowset *, dd_rowindex *, dd_ErrorType *); /* 094 */
-dd_boolean dd_MatrixRedundancyRemove(dd_MatrixPtr *M, dd_rowset *redset,dd_rowindex *newpos, dd_ErrorType *); /* 094 */
-dd_boolean dd_FindRelativeInterior(dd_MatrixPtr, dd_rowset *, dd_rowset *, dd_LPSolutionPtr *, dd_ErrorType *);  /* 094 */
-dd_boolean dd_ExistsRestrictedFace(dd_MatrixPtr, dd_rowset, dd_rowset, dd_ErrorType *);  /* 0.94 */
-dd_boolean dd_ExistsRestrictedFace2(dd_MatrixPtr, dd_rowset, dd_rowset, dd_LPSolutionPtr *, dd_ErrorType *); /* 0.94 */
+dd_boolean dd_ImplicitLinearity(dd_MatrixPtr M, dd_rowrange itest, dd_Arow certificate, dd_ErrorType * error);  /* 092 */
+dd_rowset dd_ImplicitLinearityRows(dd_MatrixPtr M, dd_ErrorType * error);  /* 092  */
+int dd_FreeOfImplicitLinearity(dd_MatrixPtr M, dd_Arow certificate, dd_rowset * imp_linrows, dd_ErrorType * error) ; /* 094 */
+dd_boolean dd_MatrixCanonicalizeLinearity(dd_MatrixPtr * M, dd_rowset * impl_linset,dd_rowindex * newpos, dd_ErrorType * error); /* 094 */
+dd_boolean dd_MatrixCanonicalize(dd_MatrixPtr * M, dd_rowset * impl_linset, dd_rowset * redset, dd_rowindex * newpos, dd_ErrorType * error); /* 094 */
+dd_boolean dd_MatrixRedundancyRemove(dd_MatrixPtr *M, dd_rowset *redset,dd_rowindex *newpos, dd_ErrorType * error); /* 094 */
+dd_boolean dd_FindRelativeInterior(dd_MatrixPtr M, dd_rowset * ImL, dd_rowset * Lbasis, dd_LPSolutionPtr * lps, dd_ErrorType * err);  /* 094 */
+dd_boolean dd_ExistsRestrictedFace(dd_MatrixPtr M, dd_rowset R, dd_rowset S, dd_ErrorType * err);  /* 0.94 */
+dd_boolean dd_ExistsRestrictedFace2(dd_MatrixPtr M, dd_rowset R, dd_rowset S, dd_LPSolutionPtr * lps, dd_ErrorType * err); /* 0.94 */
 
-dd_SetFamilyPtr dd_Matrix2Adjacency(dd_MatrixPtr, dd_ErrorType *);  /* 093 */
-dd_SetFamilyPtr dd_Matrix2WeakAdjacency(dd_MatrixPtr, dd_ErrorType *);  /* 093a */
-long dd_MatrixRank(dd_MatrixPtr, dd_rowset, dd_colset, dd_rowset *, dd_colset *);
+dd_SetFamilyPtr dd_Matrix2Adjacency(dd_MatrixPtr M, dd_ErrorType * error);  /* 093 */
+dd_SetFamilyPtr dd_Matrix2WeakAdjacency(dd_MatrixPtr M, dd_ErrorType * error);  /* 093a */
+long dd_MatrixRank(dd_MatrixPtr M, dd_rowset ignoredrows, dd_colset ignoredcols, dd_rowset * rowbasis, dd_colset * colbasis);
 
 /* Matrix Basic Operations */
-dd_MatrixPtr dd_MatrixCopy(dd_MatrixPtr); /* a new name for dd_CopyMatrix */
-dd_MatrixPtr dd_CopyMatrix(dd_MatrixPtr); /* 090c, kept for compatibility */
-dd_MatrixPtr dd_MatrixNormalizedCopy(dd_MatrixPtr); /* 094 */
-dd_MatrixPtr dd_MatrixNormalizedSortedCopy(dd_MatrixPtr,dd_rowindex*); /* 094 */
-dd_MatrixPtr dd_MatrixUniqueCopy(dd_MatrixPtr,dd_rowindex*); /* 094 */
-dd_MatrixPtr dd_MatrixNormalizedSortedUniqueCopy(dd_MatrixPtr,dd_rowindex*); /* 094 */
-dd_MatrixPtr dd_MatrixSortedUniqueCopy(dd_MatrixPtr,dd_rowindex*); /* 094 */
+dd_MatrixPtr dd_MatrixCopy(dd_MatrixPtr M); /* a new name for dd_CopyMatrix */
+dd_MatrixPtr dd_CopyMatrix(dd_MatrixPtr M); /* 090c, kept for compatibility */
+dd_MatrixPtr dd_MatrixNormalizedCopy(dd_MatrixPtr M); /* 094 */
+dd_MatrixPtr dd_MatrixNormalizedSortedCopy(dd_MatrixPtr M,dd_rowindex* newpos); /* 094 */
+dd_MatrixPtr dd_MatrixUniqueCopy(dd_MatrixPtr M,dd_rowindex* newpos); /* 094 */
+dd_MatrixPtr dd_MatrixNormalizedSortedUniqueCopy(dd_MatrixPtr M,dd_rowindex* newpos); /* 094 */
+dd_MatrixPtr dd_MatrixSortedUniqueCopy(dd_MatrixPtr M,dd_rowindex* newpos); /* 094 */
 
-dd_MatrixPtr dd_MatrixAppend(dd_MatrixPtr, dd_MatrixPtr);  /* a name for dd_AppendMatrix */
-dd_MatrixPtr dd_AppendMatrix(dd_MatrixPtr, dd_MatrixPtr);  /* 090c, kept for compatibility */
+dd_MatrixPtr dd_MatrixAppend(dd_MatrixPtr M1, dd_MatrixPtr M2);  /* a name for dd_AppendMatrix */
+dd_MatrixPtr dd_AppendMatrix(dd_MatrixPtr M1, dd_MatrixPtr M2);  /* 090c, kept for compatibility */
 
-int dd_MatrixAppendTo(dd_MatrixPtr*, dd_MatrixPtr);  /* 092 */
+int dd_MatrixAppendTo(dd_MatrixPtr* M1, dd_MatrixPtr M2);  /* 092 */
 int dd_Remove(dd_MatrixPtr*, dd_rowrange);  /* 092 */
-dd_MatrixPtr dd_MatrixSubmatrix(dd_MatrixPtr, dd_rowset delset); /* 092 */
-dd_MatrixPtr dd_MatrixSubmatrix2(dd_MatrixPtr, dd_rowset delset,dd_rowindex*); /* 094.  It returns new row positions. */
-dd_MatrixPtr dd_MatrixSubmatrix2L(dd_MatrixPtr, dd_rowset delset,dd_rowindex*); /* 094.  Linearity shifted up. */
-int dd_MatrixShiftupLinearity(dd_MatrixPtr *,dd_rowindex *); /* 094 */
+dd_MatrixPtr dd_MatrixSubmatrix(dd_MatrixPtr M, dd_rowset delset); /* 092 */
+dd_MatrixPtr dd_MatrixSubmatrix2(dd_MatrixPtr M, dd_rowset delset,dd_rowindex* newpos); /* 094.  It returns new row positions. */
+dd_MatrixPtr dd_MatrixSubmatrix2L(dd_MatrixPtr M, dd_rowset delset,dd_rowindex* newpos); /* 094.  Linearity shifted up. */
+int dd_MatrixShiftupLinearity(dd_MatrixPtr * M,dd_rowindex * newpos); /* 094 */
 int dd_MatrixRowRemove(dd_MatrixPtr *M, dd_rowrange r); /* 092 */
-int dd_MatrixRowRemove2(dd_MatrixPtr *M, dd_rowrange r,dd_rowindex*); /* 094*/
+int dd_MatrixRowRemove2(dd_MatrixPtr *M, dd_rowrange r,dd_rowindex* newpos); /* 094*/
 int dd_MatrixRowsRemove(dd_MatrixPtr *M, dd_rowset delset); /* 094 */
-int dd_MatrixRowsRemove2(dd_MatrixPtr *M, dd_rowset delset,dd_rowindex*); /* 094 */
+int dd_MatrixRowsRemove2(dd_MatrixPtr *M, dd_rowset delset,dd_rowindex* newpos); /* 094 */
 
 /* input/output */
-void dd_SetInputFile(FILE **f,dd_DataFileType inputfile, dd_ErrorType *);
-void dd_SetWriteFileName(dd_DataFileType, dd_DataFileType, char, dd_RepresentationType);
+void dd_SetInputFile(FILE **f,dd_DataFileType inputfile, dd_ErrorType * Error);
+void dd_SetWriteFileName(dd_DataFileType inputfile, dd_DataFileType outfile, char cflag, dd_RepresentationType rep);
 
-void dd_WriteAmatrix(FILE *, dd_Amatrix, dd_rowrange, dd_colrange);
-void dd_WriteArow(FILE *f, dd_Arow a, dd_colrange);
-void dd_WriteBmatrix(FILE *, dd_colrange, dd_Bmatrix T);
-void dd_WriteMatrix(FILE *, dd_MatrixPtr);
-void dd_MatrixIntegerFilter(dd_MatrixPtr);
-void dd_WriteReal(FILE *, mytype);
+void dd_WriteAmatrix(FILE * f, dd_Amatrix A, dd_rowrange rowmax, dd_colrange colmax);
+void dd_WriteArow(FILE *f, dd_Arow a, dd_colrange d);
+void dd_WriteBmatrix(FILE * f, dd_colrange d_size, dd_Bmatrix B);
+void dd_WriteMatrix(FILE * f, dd_MatrixPtr M);
+void dd_MatrixIntegerFilter(dd_MatrixPtr M);
+void dd_WriteReal(FILE * f, mytype x);
 void dd_WriteNumber(FILE *f, mytype x); 
     /* write a number depending on the arithmetic used.  */
-void dd_WritePolyFile(FILE *, dd_PolyhedraPtr);
-void dd_WriteRunningMode(FILE *, dd_PolyhedraPtr);
-void dd_WriteErrorMessages(FILE *, dd_ErrorType);
-void dd_WriteSetFamily(FILE *, dd_SetFamilyPtr);
-void dd_WriteSetFamilyCompressed(FILE *, dd_SetFamilyPtr);
-void dd_WriteProgramDescription(FILE *);
-void dd_WriteDDTimes(FILE *, dd_PolyhedraPtr);
-void dd_WriteTimes(FILE *, time_t, time_t);
-void dd_WriteIncidence(FILE *, dd_PolyhedraPtr);
-void dd_WriteAdjacency(FILE *, dd_PolyhedraPtr);
-void dd_WriteInputAdjacency(FILE *, dd_PolyhedraPtr);
-void dd_WriteInputIncidence(FILE *, dd_PolyhedraPtr);
+void dd_WritePolyFile(FILE * f, dd_PolyhedraPtr poly);
+void dd_WriteRunningMode(FILE * f, dd_PolyhedraPtr poly);
+void dd_WriteErrorMessages(FILE * f, dd_ErrorType Error);
+void dd_WriteSetFamily(FILE * f, dd_SetFamilyPtr F);
+void dd_WriteSetFamilyCompressed(FILE * f, dd_SetFamilyPtr F);
+void dd_WriteProgramDescription(FILE * f);
+void dd_WriteDDTimes(FILE * f, dd_PolyhedraPtr poly);
+void dd_WriteTimes(FILE * f, time_t starttime, time_t endtime);
+void dd_WriteIncidence(FILE * f, dd_PolyhedraPtr poly);
+void dd_WriteAdjacency(FILE * f, dd_PolyhedraPtr poly);
+void dd_WriteInputAdjacency(FILE * f, dd_PolyhedraPtr poly);
+void dd_WriteInputIncidence(FILE * f, dd_PolyhedraPtr poly);
 
 /* functions and types for LP solving */
 
-dd_LPPtr dd_Matrix2LP(dd_MatrixPtr, dd_ErrorType *);
+dd_LPPtr dd_Matrix2LP(dd_MatrixPtr M, dd_ErrorType * err);
   /* Load a matrix to create an LP object. */
   
-dd_LPPtr dd_Matrix2Feasibility(dd_MatrixPtr, dd_ErrorType *);
+dd_LPPtr dd_Matrix2Feasibility(dd_MatrixPtr M, dd_ErrorType * err);
   /* Load a matrix to create an LP object for feasibility (obj == 0) .*/  /*  094 */
   
-dd_LPPtr dd_Matrix2Feasibility2(dd_MatrixPtr, dd_rowset, dd_rowset, dd_ErrorType *);
+dd_LPPtr dd_Matrix2Feasibility2(dd_MatrixPtr M, dd_rowset R, dd_rowset S, dd_ErrorType * err);
   /* Load a matrix to create an LP object for feasibility with additional equality and
    strict inequality constraints. */  /*  094 */
 
-dd_boolean dd_LPSolve(dd_LPPtr,dd_LPSolverType,dd_ErrorType *);
-dd_boolean dd_LPSolve0(dd_LPPtr,dd_LPSolverType,dd_ErrorType *);
-void dd_CrissCrossSolve(dd_LPPtr lp,dd_ErrorType *);
-void dd_DualSimplexSolve(dd_LPPtr lp,dd_ErrorType *);
+dd_boolean dd_LPSolve(dd_LPPtr lp,dd_LPSolverType solver,dd_ErrorType * err);
+dd_boolean dd_LPSolve0(dd_LPPtr lp,dd_LPSolverType solver,dd_ErrorType * err);
+void dd_CrissCrossSolve(dd_LPPtr lp,dd_ErrorType * err);
+void dd_DualSimplexSolve(dd_LPPtr lp,dd_ErrorType * err);
 
-dd_LPPtr dd_MakeLPforInteriorFinding(dd_LPPtr);  
-dd_LPSolutionPtr dd_CopyLPSolution(dd_LPPtr);  /* 0.90c */
-void dd_WriteLP(FILE *, dd_LPPtr); /* 092 */
+dd_LPPtr dd_MakeLPforInteriorFinding(dd_LPPtr lp);  
+dd_LPSolutionPtr dd_CopyLPSolution(dd_LPPtr lp);  /* 0.90c */
+void dd_WriteLP(FILE * f, dd_LPPtr lp); /* 092 */
 
-dd_LPPtr dd_CreateLPData(dd_LPObjectiveType,dd_NumberType,dd_rowrange,dd_colrange);
-int dd_LPReverseRow(dd_LPPtr, dd_rowrange);
+dd_LPPtr dd_CreateLPData(dd_LPObjectiveType obj,dd_NumberType nt,dd_rowrange m,dd_colrange d);
+int dd_LPReverseRow(dd_LPPtr lp, dd_rowrange i);
     /* reverse the i-th row (1 <= i <= no. of rows) */
-int dd_LPReplaceRow(dd_LPPtr, dd_rowrange, dd_Arow);
+int dd_LPReplaceRow(dd_LPPtr lp, dd_rowrange i, dd_Arow a);
     /* replace the i-th row (1 <= i <= no. of rows) */
-dd_Arow dd_LPCopyRow(dd_LPPtr, dd_rowrange);
+dd_Arow dd_LPCopyRow(dd_LPPtr lp, dd_rowrange i);
     /* copy the i-th row (1 <= i <= no. of rows) */
 
-void dd_FreeLPData(dd_LPPtr);
-void dd_FreeLPSolution(dd_LPSolutionPtr);
+void dd_FreeLPData(dd_LPPtr lp);
+void dd_FreeLPSolution(dd_LPSolutionPtr lps);
 
-void dd_WriteLPResult(FILE *, dd_LPPtr, dd_ErrorType);
+void dd_WriteLPResult(FILE * f, dd_LPPtr lp, dd_ErrorType err);
 void dd_WriteLPErrorMessages(FILE *, dd_ErrorType);
-void dd_WriteLPTimes(FILE *, dd_LPPtr);
+void dd_WriteLPTimes(FILE * f, dd_LPPtr lp);
 void dd_WriteLPStats(FILE *f);
 void dd_WriteLPMode(FILE *f);
 
-dd_MatrixPtr dd_FourierElimination(dd_MatrixPtr,dd_ErrorType *);
-dd_MatrixPtr dd_BlockElimination(dd_MatrixPtr, dd_colset, dd_ErrorType *);
+dd_MatrixPtr dd_FourierElimination(dd_MatrixPtr M,dd_ErrorType * error);
+dd_MatrixPtr dd_BlockElimination(dd_MatrixPtr M, dd_colset delset, dd_ErrorType * error);
 
 /* ---------- FUNCTIONS MEANT TO BE NON-PUBLIC ---------- */
-void dd_QuickSort(dd_rowindex, long, long, dd_Amatrix, long);
-void dd_RandomPermutation(dd_rowindex, long, unsigned int seed);
-void dd_UniqueRows(dd_rowindex, long, long, dd_Amatrix, long, dd_rowset, long *);
+void dd_QuickSort(dd_rowindex OV, long p, long r, dd_Amatrix A, long dmax);
+void dd_RandomPermutation(dd_rowindex OV, long t, unsigned int seed);
+void dd_UniqueRows(dd_rowindex OV, long p, long r, dd_Amatrix A, long dmax, dd_rowset preferred, long * uniqrows);
 
-dd_boolean dd_DoubleDescription(dd_PolyhedraPtr, dd_ErrorType*);
-dd_boolean dd_DoubleDescription2(dd_PolyhedraPtr, dd_RowOrderType, dd_ErrorType *);
+dd_boolean dd_DoubleDescription(dd_PolyhedraPtr poly, dd_ErrorType* err);
+dd_boolean dd_DoubleDescription2(dd_PolyhedraPtr poly, dd_RowOrderType horder, dd_ErrorType * err);
 
-void dd_FreeDDMemory0(dd_ConePtr);
+void dd_FreeDDMemory0(dd_ConePtr cone);
 void dd_fread_rational_value (FILE *f, mytype value);
 void dd_sread_rational_value (const char *s, mytype value);
-void dd_AddNewHalfspace1(dd_ConePtr, dd_rowrange);
-void dd_AddNewHalfspace2(dd_ConePtr, dd_rowrange);
-void dd_AddRay(dd_ConePtr, mytype *);
-void dd_AddArtificialRay(dd_ConePtr);
-void dd_AValue(mytype*,dd_colrange, dd_Amatrix, mytype *, dd_rowrange);
-void dd_CheckAdjacency(dd_ConePtr, dd_RayPtr*, dd_RayPtr*, dd_boolean *);
-void dd_CheckEquality(dd_colrange, dd_RayPtr *, dd_RayPtr *, dd_boolean *);
-void dd_ComputeRowOrderVector(dd_ConePtr);
-void dd_ConditionalAddEdge(dd_ConePtr,dd_RayPtr, dd_RayPtr, dd_RayPtr);
-void dd_CopyArow(mytype *, mytype *, dd_colrange);
-void dd_CopyNormalizedAmatrix(mytype **, mytype **, dd_rowrange, dd_colrange);
-void dd_CopyNormalizedArow(mytype *, mytype *, dd_colrange);
-void dd_CopyAmatrix(mytype **, mytype **, dd_rowrange, dd_colrange);
-void dd_PermuteCopyAmatrix(mytype **, mytype **, dd_rowrange, dd_colrange, dd_rowindex);
-void dd_PermutePartialCopyAmatrix(mytype **, mytype **, dd_rowrange, dd_colrange, dd_rowindex, dd_rowrange, dd_rowrange);
-void dd_SetMatrixObjective(dd_MatrixPtr, dd_LPObjectiveType);
-void dd_SetMatrixNumberType(dd_MatrixPtr, dd_NumberType);
-void dd_SetMatrixRepresentationType(dd_MatrixPtr, dd_RepresentationType);
-void dd_CopyBmatrix(dd_colrange, dd_Bmatrix T, dd_Bmatrix TCOPY);
-void dd_CopyRay(mytype *, dd_colrange, dd_RayPtr, dd_RepresentationType, dd_colindex);
-void dd_CreateInitialEdges(dd_ConePtr);
-void dd_CreateNewRay(dd_ConePtr, dd_RayPtr, dd_RayPtr, dd_rowrange);
-void dd_Eliminate(dd_ConePtr, dd_RayPtr*);
-void dd_EvaluateARay1(dd_rowrange, dd_ConePtr);
-void dd_EvaluateARay2(dd_rowrange, dd_ConePtr);
-void dd_FeasibilityIndices(long *, long *, dd_rowrange, dd_ConePtr);
-void dd_FindBasis(dd_ConePtr, long *rank);
-void dd_FindInitialRays(dd_ConePtr, dd_boolean *);
-void dd_ColumnReduce(dd_ConePtr);
-void dd_GaussianColumnPivot(dd_rowrange, dd_colrange, dd_Amatrix, dd_Bmatrix,  dd_rowrange, dd_colrange);
-dd_boolean dd_LexSmaller(mytype *, mytype *, long);
-dd_boolean dd_LexLarger(mytype *, mytype *, long);
-dd_boolean dd_LexEqual(mytype *, mytype *, long);
-void dd_Normalize(dd_colrange, mytype *);
-void dd_MatrixIntegerFilter(dd_MatrixPtr);
-void dd_ProcessCommandLine(FILE*,dd_MatrixPtr, const char *);
-void dd_SelectNextHalfspace(dd_ConePtr, dd_rowset, dd_rowrange *);
-void dd_SelectPivot2(dd_rowrange,dd_colrange,dd_Amatrix,
-dd_Bmatrix,dd_RowOrderType,dd_rowindex, dd_rowset,dd_rowrange,dd_rowset,
-dd_colset,dd_rowrange *,dd_colrange *,dd_boolean *);
-void dd_SelectPreorderedNext(dd_ConePtr, dd_rowset, dd_rowrange *);
-void dd_SetInequalitySets(dd_ConePtr);
-void dd_SnapToInteger(mytype, mytype);
-void dd_StoreRay1(dd_ConePtr, mytype *, dd_boolean *);
-void dd_StoreRay2(dd_ConePtr, mytype *, dd_boolean *, dd_boolean *);
-void dd_TableauEntry(mytype *, dd_rowrange, dd_colrange, dd_Amatrix, dd_Bmatrix T, dd_rowrange, dd_colrange);
-void dd_UpdateEdges(dd_ConePtr, dd_RayPtr, dd_RayPtr);
-void dd_UpdateRowOrderVector(dd_ConePtr, dd_rowset PriorityRows);
-void dd_WriteRay(FILE *, dd_colrange, dd_RayPtr,
-   dd_RepresentationType, dd_colindex);
-void dd_ZeroIndexSet(dd_rowrange, dd_colrange, dd_Amatrix, mytype *, dd_rowset);
+void dd_AddNewHalfspace1(dd_ConePtr cone, dd_rowrange hnew);
+void dd_AddNewHalfspace2(dd_ConePtr cone, dd_rowrange hnew);
+void dd_AddRay(dd_ConePtr cone, mytype * p);
+void dd_AddArtificialRay(dd_ConePtr cone);
+void dd_AValue(mytype* val,dd_colrange d_size, dd_Amatrix A, mytype * p, dd_rowrange i);
+void dd_CheckAdjacency(dd_ConePtr cone, dd_RayPtr* RP1, dd_RayPtr* RP2, dd_boolean * adjacent);
+void dd_CheckEquality(dd_colrange d_size, dd_RayPtr * RP1, dd_RayPtr * RP2, dd_boolean * equal);
+void dd_ComputeRowOrderVector(dd_ConePtr cone);
+void dd_ConditionalAddEdge(dd_ConePtr cone,dd_RayPtr Ray1, dd_RayPtr Ray2, dd_RayPtr ValidFirstRay);
+void dd_CopyArow(mytype * acopy, mytype * a, dd_colrange d);
+void dd_CopyNormalizedAmatrix(mytype ** Acopy, mytype ** A, dd_rowrange m, dd_colrange d);
+void dd_CopyNormalizedArow(mytype * acopy, mytype * a, dd_colrange d);
+void dd_CopyAmatrix(mytype ** Acopy, mytype ** A, dd_rowrange m, dd_colrange d);
+void dd_PermuteCopyAmatrix(mytype ** Acopy, mytype ** A, dd_rowrange m, dd_colrange d, dd_rowindex roworder);
+void dd_PermutePartialCopyAmatrix(mytype ** Acopy, mytype ** A, dd_rowrange m, dd_colrange d, dd_rowindex roworder, dd_rowrange p, dd_rowrange q);
+void dd_SetMatrixObjective(dd_MatrixPtr M, dd_LPObjectiveType objective);
+void dd_SetMatrixNumberType(dd_MatrixPtr M, dd_NumberType numbtype);
+void dd_SetMatrixRepresentationType(dd_MatrixPtr M, dd_RepresentationType representation);
+void dd_CopyBmatrix(dd_colrange d_size, dd_Bmatrix T, dd_Bmatrix TCOPY);
+void dd_CopyRay(mytype * a, dd_colrange d_origsize, dd_RayPtr RR, dd_RepresentationType rep, dd_colindex reducedcol);
+void dd_CreateInitialEdges(dd_ConePtr cone);
+void dd_CreateNewRay(dd_ConePtr cone, dd_RayPtr Ptr1, dd_RayPtr Ptr2, dd_rowrange ii);
+void dd_Eliminate(dd_ConePtr cone, dd_RayPtr* Ptr);
+void dd_EvaluateARay1(dd_rowrange i, dd_ConePtr cone);
+void dd_EvaluateARay2(dd_rowrange i, dd_ConePtr cone);
+void dd_FeasibilityIndices(long * fnum, long * infnum, dd_rowrange i, dd_ConePtr cone);
+void dd_FindBasis(dd_ConePtr cone, long *rank);
+void dd_FindInitialRays(dd_ConePtr cone, dd_boolean * found);
+void dd_ColumnReduce(dd_ConePtr cone);
+void dd_GaussianColumnPivot(dd_rowrange m_size, dd_colrange d_size, dd_Amatrix X, dd_Bmatrix T,  dd_rowrange r, dd_colrange s);
+dd_boolean dd_LexSmaller(mytype * v1, mytype * v2, long dmax);
+dd_boolean dd_LexLarger(mytype * v1, mytype * v2, long dmax);
+dd_boolean dd_LexEqual(mytype * v1, mytype * v2, long dmax);
+void dd_Normalize(dd_colrange d_size, mytype * V);
+void dd_MatrixIntegerFilter(dd_MatrixPtr M);
+void dd_ProcessCommandLine(FILE* f,dd_MatrixPtr M, const char * line);
+void dd_SelectNextHalfspace(dd_ConePtr cone, dd_rowset excluded, dd_rowrange * hh);
+void dd_SelectPivot2(dd_rowrange m_size,dd_colrange d_size,dd_Amatrix A,
+dd_Bmatrix T,dd_RowOrderType roworder,dd_rowindex ordervec, dd_rowset equalityset,dd_rowrange rowmax,dd_rowset NopivotRow,
+dd_colset NopivotCol,dd_rowrange * r,dd_colrange * s,dd_boolean * selected);
+void dd_SelectPreorderedNext(dd_ConePtr cone, dd_rowset excluded, dd_rowrange * hh);
+void dd_SetInequalitySets(dd_ConePtr cone);
+void dd_SnapToInteger(mytype y, mytype x);
+void dd_StoreRay1(dd_ConePtr cone, mytype * p, dd_boolean * feasible);
+void dd_StoreRay2(dd_ConePtr cone, mytype * p, dd_boolean * feasible, dd_boolean * weaklyfeasible);
+void dd_TableauEntry(mytype * x, dd_rowrange m_size, dd_colrange d_size, dd_Amatrix X, dd_Bmatrix T, dd_rowrange r, dd_colrange s);
+void dd_UpdateEdges(dd_ConePtr cone, dd_RayPtr RRbegin, dd_RayPtr RRend);
+void dd_UpdateRowOrderVector(dd_ConePtr cone, dd_rowset PriorityRows);
+void dd_WriteRay(FILE * f, dd_colrange d_origsize, dd_RayPtr RR,
+   dd_RepresentationType rep, dd_colindex reducedcol);
+void dd_ZeroIndexSet(dd_rowrange m_size, dd_colrange d_size, dd_Amatrix A, mytype * x, dd_rowset ZS);
 
 /* New functions to handle data loading, NON-PUBLIC */
-dd_NumberType dd_GetNumberType(const char *);
-dd_ConePtr dd_ConeDataLoad(dd_PolyhedraPtr);
-dd_PolyhedraPtr dd_CreatePolyhedraData(dd_rowrange, dd_colrange);
-dd_boolean dd_InitializeConeData(dd_rowrange, dd_colrange, dd_ConePtr*);
-dd_boolean dd_AppendMatrix2Poly(dd_PolyhedraPtr*, dd_MatrixPtr);
+dd_NumberType dd_GetNumberType(const char * line);
+dd_ConePtr dd_ConeDataLoad(dd_PolyhedraPtr poly);
+dd_PolyhedraPtr dd_CreatePolyhedraData(dd_rowrange m, dd_colrange d);
+dd_boolean dd_InitializeConeData(dd_rowrange m, dd_colrange d, dd_ConePtr* cone);
+dd_boolean dd_AppendMatrix2Poly(dd_PolyhedraPtr* poly, dd_MatrixPtr M);
 
 #if defined(__cplusplus)
 }

--- a/lib-src/cddio.c
+++ b/lib-src/cddio.c
@@ -18,7 +18,7 @@
 #include <string.h>
 
 /* void dd_fread_rational_value (FILE *, mytype *); */
-void dd_SetLinearity(dd_MatrixPtr, char *);
+void dd_SetLinearity(dd_MatrixPtr M, char * line);
 
 void dd_SetInputFile(FILE **f,dd_DataFileType inputfile,dd_ErrorType *Error)
 {

--- a/lib-src/cddlp.c
+++ b/lib-src/cddlp.c
@@ -29,45 +29,45 @@
 typedef set_type rowset;  /* set_type defined in setoper.h */
 typedef set_type colset;
 
-void dd_CrissCrossSolve(dd_LPPtr lp,dd_ErrorType *);
-void dd_DualSimplexSolve(dd_LPPtr lp,dd_ErrorType *);
-void dd_CrissCrossMinimize(dd_LPPtr,dd_ErrorType *);
-void dd_CrissCrossMaximize(dd_LPPtr,dd_ErrorType *);
-void dd_DualSimplexMinimize(dd_LPPtr,dd_ErrorType *);
-void dd_DualSimplexMaximize(dd_LPPtr,dd_ErrorType *);
-void dd_FindLPBasis(dd_rowrange,dd_colrange,dd_Amatrix,dd_Bmatrix,dd_rowindex,dd_rowset,
-    dd_colindex,dd_rowindex,dd_rowrange,dd_colrange,
-    dd_colrange *,int *,dd_LPStatusType *,long *);
-void dd_FindDualFeasibleBasis(dd_rowrange,dd_colrange,dd_Amatrix,dd_Bmatrix,dd_rowindex,
-    dd_colindex,long *,dd_rowrange,dd_colrange,dd_boolean,
-    dd_colrange *,dd_ErrorType *,dd_LPStatusType *,long *, long maxpivots);
+void dd_CrissCrossSolve(dd_LPPtr lp,dd_ErrorType * err);
+void dd_DualSimplexSolve(dd_LPPtr lp,dd_ErrorType * err);
+void dd_CrissCrossMinimize(dd_LPPtr lp,dd_ErrorType * err);
+void dd_CrissCrossMaximize(dd_LPPtr lp,dd_ErrorType * err);
+void dd_DualSimplexMinimize(dd_LPPtr lp,dd_ErrorType * err);
+void dd_DualSimplexMaximize(dd_LPPtr lp,dd_ErrorType * err);
+void dd_FindLPBasis(dd_rowrange m_size,dd_colrange d_size,dd_Amatrix A,dd_Bmatrix T,dd_rowindex OV,dd_rowset equalityset,
+    dd_colindex nbindex,dd_rowindex bflag,dd_rowrange objrow,dd_colrange rhscol,
+    dd_colrange * cs,int * found,dd_LPStatusType * lps,long * pivot_no);
+void dd_FindDualFeasibleBasis(dd_rowrange m_size,dd_colrange d_size,dd_Amatrix A,dd_Bmatrix T,dd_rowindex OV,
+    dd_colindex nbindex,long * bflag,dd_rowrange objrow,dd_colrange rhscol,dd_boolean lexicopivot,
+    dd_colrange * s,dd_ErrorType * err,dd_LPStatusType * lps,long * pivot_no, long maxpivots);
 
 
 #ifdef GMPRATIONAL
-void dd_BasisStatus(ddf_LPPtr lpf, dd_LPPtr lp, dd_boolean*);
-void dd_BasisStatusMinimize(dd_rowrange,dd_colrange, dd_Amatrix,dd_Bmatrix,dd_rowset,
-    dd_rowrange,dd_colrange,ddf_LPStatusType,mytype *,dd_Arow,dd_Arow,dd_rowset,ddf_colindex,
-    ddf_rowrange,ddf_colrange,dd_colrange *,long *, int *, int *);
-void dd_BasisStatusMaximize(dd_rowrange,dd_colrange,dd_Amatrix,dd_Bmatrix,dd_rowset,
-    dd_rowrange,dd_colrange,ddf_LPStatusType,mytype *,dd_Arow,dd_Arow,dd_rowset,ddf_colindex,
-    ddf_rowrange,ddf_colrange,dd_colrange *,long *, int *, int *);
+void dd_BasisStatus(ddf_LPPtr lpf, dd_LPPtr lp, dd_boolean* LPScorrect);
+void dd_BasisStatusMinimize(dd_rowrange m_size,dd_colrange d_size, dd_Amatrix A,dd_Bmatrix T,dd_rowset equalityset,
+    dd_rowrange objrow,dd_colrange rhscol,ddf_LPStatusType LPS,mytype * optvalue,dd_Arow sol,dd_Arow dsol,dd_rowset posset,ddf_colindex nbindex,
+    ddf_rowrange re,ddf_colrange se,dd_colrange * nse,long * pivots, int * found, int * LPScorrect);
+void dd_BasisStatusMaximize(dd_rowrange m_size,dd_colrange d_size,dd_Amatrix A,dd_Bmatrix T,dd_rowset equalityset,
+    dd_rowrange objrow,dd_colrange rhscol,ddf_LPStatusType LPS,mytype * optvalue,dd_Arow sol,dd_Arow dsol,dd_rowset posset,ddf_colindex nbindex,
+    ddf_rowrange re,ddf_colrange se,dd_colrange * nse,long * pivots, int * found, int * LPScorrect);
 #endif
 
-void dd_WriteBmatrix(FILE *f,dd_colrange d_size,dd_Bmatrix T);
+void dd_WriteBmatrix(FILE *f,dd_colrange d_size,dd_Bmatrix B);
 void dd_SetNumberType(char *line,dd_NumberType *number,dd_ErrorType *Error);
 void dd_ComputeRowOrderVector2(dd_rowrange m_size,dd_colrange d_size,dd_Amatrix A,
     dd_rowindex OV,dd_RowOrderType ho,unsigned int rseed);
 void dd_SelectPreorderedNext2(dd_rowrange m_size,dd_colrange d_size,
     rowset excluded,dd_rowindex OV,dd_rowrange *hnext);
-void dd_SetSolutions(dd_rowrange,dd_colrange,
-   dd_Amatrix,dd_Bmatrix,dd_rowrange,dd_colrange,dd_LPStatusType,
-   mytype *,dd_Arow,dd_Arow,dd_rowset,dd_colindex,dd_rowrange,dd_colrange,dd_rowindex);
+void dd_SetSolutions(dd_rowrange m_size,dd_colrange d_size,
+   dd_Amatrix A,dd_Bmatrix T,dd_rowrange objrow,dd_colrange rhscol,dd_LPStatusType LPS,
+   mytype * optvalue,dd_Arow sol,dd_Arow dsol,dd_rowset posset,dd_colindex nbindex,dd_rowrange re,dd_colrange se,dd_rowindex bflag);
    
-void dd_WriteTableau(FILE *,dd_rowrange,dd_colrange,dd_Amatrix,dd_Bmatrix,
-  dd_colindex,dd_rowindex);
+void dd_WriteTableau(FILE * f,dd_rowrange m_size,dd_colrange d_size,dd_Amatrix A,dd_Bmatrix T,
+  dd_colindex nbindex,dd_rowindex bflag);
 
-void dd_WriteSignTableau(FILE *,dd_rowrange,dd_colrange,dd_Amatrix,dd_Bmatrix,
-  dd_colindex,dd_rowindex);
+void dd_WriteSignTableau(FILE * f,dd_rowrange m_size,dd_colrange d_size,dd_Amatrix A,dd_Bmatrix T,
+  dd_colindex nbindex,dd_rowindex bflag);
 
 
 dd_LPSolutionPtr dd_CopyLPSolution(dd_LPPtr lp)

--- a/lib-src/cddmp.h
+++ b/lib-src/cddmp.h
@@ -99,23 +99,23 @@
 extern "C" {
 #endif
 
-void ddd_mpq_set_si(mytype,signed long);
-void ddd_init(mytype);  
-void ddd_clear(mytype);
-void ddd_set(mytype,mytype);
-void ddd_set_d(mytype,double);
-void ddd_set_si(mytype,signed long);
-void ddd_set_si2(mytype,signed long, unsigned long);
-void ddd_add(mytype,mytype,mytype);
-void ddd_sub(mytype,mytype,mytype);
-void ddd_mul(mytype,mytype,mytype);
-void ddd_div(mytype,mytype,mytype);
-void ddd_neg(mytype,mytype);
-void ddd_inv(mytype,mytype);
-int ddd_cmp(mytype,mytype);
-int ddd_sgn(mytype);
-double ddd_get_d(mytype);
-void ddd_mpq_set_si(mytype,signed long);
+void ddd_mpq_set_si(mytype a,signed long b);
+void ddd_init(mytype a);  
+void ddd_clear(mytype a);
+void ddd_set(mytype a,mytype b);
+void ddd_set_d(mytype a,double b);
+void ddd_set_si(mytype a,signed long b);
+void ddd_set_si2(mytype a,signed long b, unsigned long c);
+void ddd_add(mytype a,mytype b,mytype c);
+void ddd_sub(mytype a,mytype b,mytype c);
+void ddd_mul(mytype a,mytype b,mytype c);
+void ddd_div(mytype a,mytype b,mytype c);
+void ddd_neg(mytype a,mytype b);
+void ddd_inv(mytype a,mytype b);
+int ddd_cmp(mytype a,mytype b);
+int ddd_sgn(mytype a);
+double ddd_get_d(mytype a);
+void ddd_mpq_set_si(mytype a,signed long b);
 
 void dd_set_global_constants(void);
 void dd_free_global_constants(void);  /* 094d */

--- a/lib-src/setoper.h
+++ b/lib-src/setoper.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 unsigned long set_blocks(long len);
-void set_initialize(set_type *setp,long len);
+void set_initialize(set_type *setp,long length);
 void set_free(set_type set);
 void set_emptyset(set_type set);
 void set_copy(set_type setcopy,set_type set);

--- a/news/parameter-names.rst
+++ b/news/parameter-names.rst
@@ -1,7 +1,3 @@
 **Added:**
 
 * Parameter names in function declarations.
-
-**Changed:**
-
-* Parameter names in function declarations to be consistent with function definition.

--- a/news/parameter-names.rst
+++ b/news/parameter-names.rst
@@ -1,0 +1,7 @@
+**Added:**
+
+* Parameter names in function declarations.
+
+**Changed:**
+
+* Parameter names in function declarations to be consistent with function definition.


### PR DESCRIPTION
I found it very helpful if variable names are present in the function declaration, so would like to contribute this back to the project. For example:

```c
void dd_LinearComb(mytype, mytype, mytype, mytype, mytype); // before
void dd_LinearComb(mytype lc, mytype v1, mytype c1, mytype v2, mytype c2); // after
```

This not only helps with "IntelliSense" in the code editor and considered good style, but also helps with automatic language binding generation tools which use the header files to extract the name of the function and the names of the parameters (this is what I need it for). In some of the function declarations, parameter names were already present so I hope this is a useful thing to complete.

As an example, here is the result with auto-generated bindings for the Julia language:

```julia
# before
function dd_LinearComb(arg1, arg2, arg3, arg4, arg5)
    ccall((:dd_LinearComb, libclang), Cvoid, (mytype, mytype, mytype, mytype, mytype), arg1, arg2, arg3, arg4, arg5)
end

# after
function dd_LinearComb(lc, v1, c1, v2, c2)
    ccall((:dd_LinearComb, libclang), Cvoid, (mytype, mytype, mytype, mytype, mytype), lc, v1, c1, v2, c2)
end
```

I know there is already a Julia wrapper, but it is missing some functions which I would like to use. Plus, I am interested in using cdd from other languages too.

Note, I did not change any of the formatting of the source code, sometimes there is a space after a comma and sometimes not. There were a couple places where the parameter names were not consistent between the declaration and definition, which I have also fixed. In all cases, the parameter names should now be the same ones used in the function definition. If anyone is interested, I used [clang-tidy](https://clang.llvm.org/extra/clang-tidy) to do most of the work, with `readability-inconsistent-declaration-parameter-name` and `readability-named-parameter` checks.

Also, the following are declared, but there is no definition, perhaps they can be removed completely?

```c
int dd_Remove(dd_MatrixPtr*, dd_rowrange);  /* 092 */
void dd_WriteLPErrorMessages(FILE *, dd_ErrorType);
```
