### PR TITLE
Fix segfault in blockelimination

### DIFF
--- a/lib-src/cddproj.c
+++ b/lib-src/cddproj.c
@@ -84,6 +84,12 @@ dd_MatrixPtr dd_BlockElimination(dd_MatrixPtr M, dd_colset delset, dd_ErrorType 
   /* 2. Compute the generators of the dual system. */
   dualpoly=dd_DDMatrix2Poly(Mdual, &err);
   Gdual=dd_CopyGenerators(dualpoly);
+  /* If `dualpoly->child->CompStatus != ddf_AllFound`, then
+   * `CopyGenerators` return `NULL` so we return `NULL` as well.
+   * `DDMatrix2Poly` should have set `err` to the appropriate value.
+   */
+  if (NULL == Gdual)
+      return NULL;
 
   /* 3. Take the linear combination of the original system with each generator.  */
   dproj=d-delsize;


### PR DESCRIPTION
I have had report of segfaults for calling `BlockElimination` on particular instances:
https://github.com/JuliaPolyhedra/CDDLib.jl/issues/61
https://github.com/JuliaPolyhedra/CDDLib.jl/issues/65
It turns out that `err` is set to `NumericallyInconsistent` here:
https://github.com/cddlib/cddlib/blob/87220b4001ff88bb408bee0ab69cd19806abd9e9/lib-src/cddlib.c#L263
as `cone->FeasibleRayCount!=cone->RayCount`/`cone->CompStatus!=dd_AllFound`.
For the same reason, the `Gdual` returned is `NULL`:
https://github.com/cddlib/cddlib/blob/87220b4001ff88bb408bee0ab69cd19806abd9e9/lib-src/cddio.c#L1849
So we're in a situation where `Gdual` is `NULL` and `err` is `NumericallyInconsistent`.
We have the choice of either continuing and segfaulting at
https://github.com/cddlib/cddlib/blob/87220b4001ff88bb408bee0ab69cd19806abd9e9/lib-src/cddproj.c#L90
or returning `NULL` with the correct explanation in `err`. Seems like an easy choice to make!