### PR TITLE
Copy certificate and handle errors correctly in dd_SRedundant in generator code path.

### DIFF
--- a/lib-src/cddlp.c
+++ b/lib-src/cddlp.c
@@ -2798,17 +2798,25 @@ dd_boolean dd_SRedundant(dd_MatrixPtr M, dd_rowrange itest, dd_Arow certificate,
           dd_FreeLPSolution(lps);
           lp=dd_CreateLP_V_SRedundancy(M, itest);
           dd_LPSolve(lp,dd_DualSimplex,&err);
-          lps=dd_CopyLPSolution(lp);
           if (localdebug) dd_WriteLPResult(stdout,lp,err);
-          if (dd_Positive(lps->optvalue)){
-            answer=dd_FALSE;
-            if (localdebug) fprintf(stderr,"==> %ld th point is not strongly redundant.\n",itest);
+          if (err!=dd_NoError){
+            *error=err;
+            goto _L999;
           } else {
-            answer=dd_TRUE;
-            if (localdebug) fprintf(stderr,"==> %ld th point is strongly redundant.\n",itest);
+            lps=dd_CopyLPSolution(lp);
+            for (j=0; j<lps->d; j++) {
+              dd_set(certificate[j], lps->sol[j]);
+            }
+            if (dd_Positive(lps->optvalue)){
+              answer=dd_FALSE;
+              if (localdebug) fprintf(stderr,"==> %ld th point is not strongly redundant.\n",itest);
+            } else {
+              answer=dd_TRUE;
+              if (localdebug) fprintf(stderr,"==> %ld th point is strongly redundant.\n",itest);
+            }
           }
        }
-    } 
+    }
     dd_FreeLPSolution(lps);
   }
   _L999:

--- a/news/fix-sredundant.rst
+++ b/news/fix-sredundant.rst
@@ -1,4 +1,4 @@
 **Fixed:**
 
-* Copy certificate and handle errors correctly in dd_SRedunant
-  for the V-representation code path.
+* Copy certificate and handle errors correctly in dd_SRedundant
+  for the V-representation code path

--- a/news/fix-sredundant.rst
+++ b/news/fix-sredundant.rst
@@ -1,0 +1,4 @@
+**Fixed:**
+
+* Copy certificate and handle errors correctly in dd_SRedunant
+  for the V-representation code path.


### PR DESCRIPTION
I noticed that dd_SRedundant sometimes does not return a certificate. This patch fixes that. It also ensures that errors in the linear programming solver are appropriately handled (they were ignored in this code path).