### PR TITLE
Fix generated pkg-config files for cdd and cddgmp to get correct linkage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # http://www.gnu.org/software/automake
 
 cddlib.pc
+cddgmp.pc
 Makefile.in
 /ar-lib
 /mdate-sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,3 +15,6 @@ distcheck-hook:
 
 pkgconfigdir       = $(libdir)/pkgconfig
 pkgconfig_DATA     = cddlib.pc
+if GMP
+pkgconfig_DATA    += cddgmp.pc
+endif

--- a/cddgmp.pc.in
+++ b/cddgmp.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: C library implementing Double Description Method (generating vertices, etc. of polyhedra) using GMP rationals
+Version: @PACKAGE_VERSION@
+Libs: @CDD_LDFLAGS@ -L${libdir} -lcddgmp -lgmp
+Cflags: -I${includedir} -DGMPRATIONAL

--- a/cddlib.pc.in
+++ b/cddlib.pc.in
@@ -1,10 +1,10 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@prefix@/include
+includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 Description: C library implementing Double Description Method (generating vertices, etc. of polyhedra)
 Version: @PACKAGE_VERSION@
-Libs: @CDD_LDFLAGS@ -L${libdir} @CDD_LIBS@
-Cflags: -I${includedir}
+Libs: @CDD_LDFLAGS@ -L${libdir} -lcdd
+Cflags: -I${includedir} -UGMPRATIONAL

--- a/configure.ac
+++ b/configure.ac
@@ -42,8 +42,6 @@ AC_CHECK_HEADER(gmp.h, [
 
 dnl We do not build the gmp enabled library if we don't have gmp.
 AM_CONDITIONAL([GMP], [test "x$ac_cv_lib_gmp___gmpz_init" = "xyes"])
-AS_IF([test "x$ac_cv_lib_gmp___gmpz_init" = "xyes"], [CDD_LIBS="-lcdd -lcddgmp"], [CDD_LIBS="-lcdd"])
-AC_SUBST(CDD_LIBS)
 
 dnl Check for latex to build the documentation dvi
 AC_CHECK_PROGS([latex], [latex])
@@ -61,5 +59,5 @@ dnl Check for dvips to build the documentation ps
 AC_CHECK_PROGS([dvips], [dvips])
 AM_CONDITIONAL([PS], [test "x$ac_cv_prog_dvips" != "x"])
 
-AC_CONFIG_FILES([doc/Makefile lib-src/Makefile src/Makefile Makefile cddlib.pc])
+AC_CONFIG_FILES([doc/Makefile lib-src/Makefile src/Makefile Makefile cddlib.pc cddgmp.pc])
 AC_OUTPUT

--- a/news/fix-pc.rst
+++ b/news/fix-pc.rst
@@ -1,0 +1,14 @@
+**Fixed:**
+
+* The cddlib.pc file now has correct linkage to cddlib (the non-gmp version).
+  To link against the gmp version, you can use the new cddgmp.pc file.
+  For instance::
+
+    pkg-config cddlib --cflags --libs
+
+  will fetch all compiler and link flags for the non-gmp version of cddlib,
+  and::
+
+    pkg-config cddgmp --cflags --libs
+
+  will get them for the gmp version of cddlib.


### PR DESCRIPTION
I noticed that the pkg-config file wasn't usable. This PR resurrects the excellent work in #50 by @jengelh but fixed to also include ``-lgmp`` for ``cddgmp.pc`` since otherwise linkage breaks. Fixes #49.

I've tested this against this sample application:

```c
#include <cddlib/setoper.h>
#include <cddlib/cdd.h>
int main()
{
  dd_MatrixPtr m = dd_CreateMatrix(1, 1);
  dd_set_si(m->matrix[0][0], 5);
  dd_WriteMatrix(stdout, m);
  dd_FreeMatrix(m);
}
```

Compilation:

```
gcc test.c `pkg-config cddlib --cflags --libs` -o test
gcc test.c `pkg-config cddgmp --cflags --libs` -o testgmp
```

Both compile successfully and the output shows the correct type of matrix used.