### PR TITLE
autoconf: check and add C11 support flag for msvc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,13 @@ case $host_os in
 ;;
 esac
 
+dnl Add -std:c11 flag for MSVC
+case $host_os in
+    *cygwin*|*mingw*)
+    AX_CHECK_COMPILE_FLAG([-std:c11], [AX_APPEND_FLAG([-std:c11])])
+;;
+esac
+
 dnl Look for gmp. But do not prepend -lgmp to LIBS as we do not want to link everything against gmp.
 dnl Check for GMP headers and library
 AC_CHECK_HEADER(gmp.h, [


### PR DESCRIPTION
This ensures the current master can be built with msvc. I've tested this with the cddlib on vcpkg (including the thread safe patch as well as the patch from this PR). Note this uses two macros from autoconf-archive but I don't suppose that's a big problem as all major distributions bundle this.

Also see discussion at #70.