### PR TITLE
Fix potential dd_MatrixCanonicalize segfault.

### DIFF
--- a/lib-src/cddlp.c
+++ b/lib-src/cddlp.c
@@ -3343,8 +3343,8 @@ dd_rowindex *newpos, dd_ErrorType *error) /* 094 */
    redundancies will be returned by *redset.
 */
   dd_rowrange i,k,m;
-  dd_rowindex newpos1,revpos;
-  dd_rowset redset1;
+  dd_rowindex newpos1=NULL,revpos=NULL;
+  dd_rowset redset1=NULL;
   dd_boolean success=dd_TRUE;
   
   m=(*M)->rowsize;

--- a/news/fix-canonicalize-segfault.rst
+++ b/news/fix-canonicalize-segfault.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fix potential dd_MatrixCanonicalize segfault.


### PR DESCRIPTION
If dd_MatrixCanonicalizeLinearity is not successful, then redset1 and newpos1 never get allocated, but they are freed at the end of the function... This patch fixes the problem by initializing these pointers to NULL so calling free will be a no-op, instead of a crash.