### PR TITLE
fixing typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -153,7 +153,7 @@ v093cg
 - A bug of Phase I of the dual simplex method in floating-point
   arithmetics is fixed.  The problem (bus error) occurred when input data
   is not appropriate for floating-point arithmetics.  The problem
-  occurrs even for the GMP executables as the exact LP solver first
+  occurs even for the GMP executables as the exact LP solver first
   tries to detect the terminal basis with float-point arithmetics.
 
 v093bg
@@ -173,7 +173,7 @@ v093ag
 
 v093g
 ====================
-- dd_LPSolve with GMP now runs fisrt with floating point arithmetics
+- dd_LPSolve with GMP now runs first with floating point arithmetics
   and checks with GMP the correctness of the result. New functions dd_Matrix2Adjacency,
   dd_FourierElimination, dd_BlockElimination, dd_DDMatrix2Poly2 are added.
   Some minor memory leak problems are fixed. (Thanks to the excellent
@@ -191,7 +191,7 @@ v092ag
 ====================
 - Joerg Rambau kindly created an autoconf distribution of
   cddlib-092.  This version 092a is made from Rambau's
-  version with a slight modification.  For the momoment,
+  version with a slight modification.  For the moment,
   the Mathematica cdd interface, cddmathlink (in src-mathlink),
   still needs to be handled in the conventional manner by
   editing Makefile.

--- a/doc/cddlibman.bbl
+++ b/doc/cddlibman.bbl
@@ -123,7 +123,7 @@ tp://home.imf.au.dk/ajensen/software/gfan/gfan.html}.
 
 \bibitem{m-pdcip-97}
 A.~Marzetta.
-\newblock {\em pd -- {C}-implementation of the primal-dual algoirithm}, 1997.
+\newblock {\em pd -- {C}-implementation of the primal-dual algorithm}, 1997.
 \newblock code available from
   \htmladdnormallink{http://www.cs.unb.ca/profs/bremner/pd/}
   {http://www.cs.unb.ca/profs/bremner/pd/}.
@@ -137,7 +137,7 @@ T.S. Motzkin, H.~Raiffa, GL. Thompson, and R.M. Thrall.
 \bibitem{m-cg-94}
 K.~Mulmuley.
 \newblock {\em Computational {G}eometry, {A}n {I}ntroduction {T}hrough
-  {R}andamized {A}lgorithms}.
+  {R}andomized {A}lgorithms}.
 \newblock Prentice-Hall, 1994.
 
 \bibitem{r-topcom-05}

--- a/doc/cddlibman.tex
+++ b/doc/cddlibman.tex
@@ -271,7 +271,7 @@ is to store a Polyhedra data in a straightforward manner.
 Once the user sets up a (pointer to)  {\tt dd\_MatrixType} data,
 he/she can load the data to an internal data type ({\tt dd\_PolyhedraType})
 by using functions described in the next section, and apply
-the double descrition method to get another representation.
+the double description method to get another representation.
 As an option  {\tt dd\_MatrixType} can save a linear objective function
 to be used by a linear programming solver.
 
@@ -728,7 +728,7 @@ Below  {\tt x}, {\tt y}, {\tt z}  are of type {\tt mytype}.
 Set {\tt x} to be the sum of  {\tt y} and  {\tt z}.
 
 \item[{\tt void dd\_sub(x, y, z)}]:\\
-Set {\tt x} to be the substraction of  {\tt z}  from  {\tt y}.
+Set {\tt x} to be the subtraction of  {\tt z}  from  {\tt y}.
 
 \item[{\tt void dd\_mul(x, y, z)}]:\\
 Set {\tt x} to be the multiplication of  {\tt y}  and  {\tt z}.
@@ -737,7 +737,7 @@ Set {\tt x} to be the multiplication of  {\tt y}  and  {\tt z}.
 Set {\tt x} to be the division of  {\tt y}  over  {\tt z}.
 
 \item[{\tt void dd\_inv(x, y)}]:\\
-Set {\tt x} to be the reciplocal of  {\tt y}.
+Set {\tt x} to be the reciprocal of  {\tt y}.
 
 \end{description}
 
@@ -786,7 +786,7 @@ Returns the negation of {\tt dd\_Positive(x)}.   {\tt dd\_Nonnegative(x)} works 
 \item[{\tt dd\_boolean dd\_EqualToZero(x)}]:\\
 Returns {\tt dd\_TRUE} if {\tt x} is considered zero,  and  {\tt dd\_FALSE} otherwise.
 In the GMPRATIONAL mode, the zero recognition is exact.  In the C double mode,
-this means the value is inbetween {\tt dd\_minuszero} and  {\tt dd\_zero}
+this means the value is between {\tt dd\_minuszero} and  {\tt dd\_zero}
 inclusive.
 
 \item[{\tt dd\_boolean dd\_Larger(x, y)}]:\\
@@ -952,7 +952,7 @@ negative of the cardinality, a colon ``:''
 Whenever it outputs the complements, the cardinality is negated
 so that there is no ambiguity.
 This will be considered standard for
-outputing incidence (*.icd, *ecd) and adjacency 
+outputting incidence (*.icd, *ecd) and adjacency
 (*.iad, *.ead) data in cddlib.   But there is some minor incompatibility
 with cdd/cdd+ standalone codes.
 
@@ -1032,7 +1032,7 @@ to stream {\tt f}.
 
 Starting from the version 093, the GMP version of cddlib, {\tt libcddgmp.a}, contains
 all cdd library functions in two arithmetics.   All functions with the standard prefix {\tt dd\_}
-are computed with the GMP rational arithmetic as before.  The same fuctions with
+are computed with the GMP rational arithmetic as before.  The same functions with
 the new prefix {\tt ddf\_} are now added to the library  {\tt libcddgmp.a} that are based
 on the C  double floating-point arithmetic.  Thus these functions are equivalent to
  {\tt libcdd.a} functions, except that all functions and  variable types are with prefix  {\tt ddf\_} and

--- a/doc/html.sty
+++ b/doc/html.sty
@@ -234,7 +234,7 @@
 % Basic approach:
 % to comment something out, scoop up  every line in verbatim mode
 % as macro argument, then throw it away.
-% For inclusions, both the opening and closing comands
+% For inclusions, both the opening and closing commands
 % are defined as noop
 %
 % Changed \next to \html@next to prevent clashes with other sty files

--- a/examples/bug45res.ine
+++ b/examples/bug45res.ine
@@ -8,7 +8,7 @@ Redundant rows are:3 4 5
 Nonredundant representation:
 The new row positions are as follows (orig:new).
 Each redundant row has the new number 0.
-Each deleted duplicated row has a number nagative of the row that
+Each deleted duplicated row has a number negative of the row that
 represents its equivalence class.
  1:1 2:2 3:0 4:0 5:0
 H-representation

--- a/examples/project2.ine
+++ b/examples/project2.ine
@@ -2,7 +2,7 @@
 * Project on the 3-space (x1, x2, x3) by eliminating the last
 * three variables (x4,x5,x6).  The result is project2res.ine .
 * This appears to be a very hard example to compute by
-* the straighforward Fourier or Block elimination because they
+* the straightforward Fourier or Block elimination because they
 * generate so many redundant inequalities.
 H-representation
 begin

--- a/lib-src/cddcore.c
+++ b/lib-src/cddcore.c
@@ -688,7 +688,7 @@ void dd_PermutePartialCopyAmatrix(mytype **Acopy, mytype **A, dd_rowrange m, dd_
 }
 
 // The three following functions seems trivial but they
-// are usefull when writing a wrapper, e.g. they are used by CDDLib.jl
+// are useful when writing a wrapper, e.g. they are used by CDDLib.jl
 void dd_SetMatrixObjective(dd_MatrixPtr M, dd_LPObjectiveType objective)
 {
   M->objective = objective;
@@ -1365,8 +1365,8 @@ void dd_DeleteNegativeRays(dd_ConePtr cone)
             Ptr->Next=cone->ZeroHead;
             cone->ZeroHead=Ptr;
           }
-          else{                /* store the new one inbetween ZeroPtr1 and 0 */
-            /* fprintf(stderr,"Insert inbetween\n");  */
+          else{                /* store the new one between ZeroPtr1 and 0 */
+            /* fprintf(stderr,"Insert between\n");  */
             Ptr->Next=ZeroPtr1->Next;
             ZeroPtr1->Next=Ptr;
           }
@@ -1496,7 +1496,7 @@ void dd_AddNewHalfspace1(dd_ConePtr cone, dd_rowrange hnew)
   dd_set(value1,cone->FirstRay->ARay);
   if (dd_Nonnegative(value1)) {
     if (cone->RayCount==cone->WeaklyFeasibleRayCount) cone->CompStatus=dd_AllFound;
-    goto _L99;        /* Sicne there is no hnew-infeasible ray and nothing to do */
+    goto _L99;        /* Since there is no hnew-infeasible ray and nothing to do */
   }
   else {
     RayPtr2s = RayPtr1->Next;/* RayPtr2s must point the first feasible ray */

--- a/lib-src/cddio.c
+++ b/lib-src/cddio.c
@@ -416,7 +416,7 @@ dd_MatrixPtr dd_MatrixNormalizedSortedUniqueCopy(dd_MatrixPtr M,dd_rowindex *new
 
 dd_MatrixPtr dd_MatrixSortedUniqueCopy(dd_MatrixPtr M,dd_rowindex *newpos)  /* 094 */
 { 
-  /* Same as dd_MatrixNormalizedSortedUniqueCopy except that it returns a unnormalized origial data
+  /* Same as dd_MatrixNormalizedSortedUniqueCopy except that it returns a unnormalized original data
      with original ordering.
   */
   dd_MatrixPtr M1=NULL,M2=NULL;
@@ -1565,7 +1565,7 @@ void dd_WriteLPMode(FILE *f)
     default: break;
   }
   
-  fprintf(f, "* Redundancy cheking solver: ");
+  fprintf(f, "* Redundancy checking solver: ");
   switch (dd_choiceRedcheckAlgorithm) {
     case dd_DualSimplex:
       fprintf(f, "DualSimplex\n");

--- a/lib-src/cddlib.c
+++ b/lib-src/cddlib.c
@@ -312,7 +312,7 @@ _L99: ;
 dd_boolean dd_DDInputAppend(dd_PolyhedraPtr *poly, dd_MatrixPtr M,
   dd_ErrorType *err)
 {
-  /* This is imcomplete.  It simply solves the problem from scratch.  */
+  /* This is incomplete.  It simply solves the problem from scratch.  */
   dd_boolean found;
   dd_ErrorType error;
 

--- a/lib-src/cddlp.c
+++ b/lib-src/cddlp.c
@@ -1128,7 +1128,7 @@ void dd_FindLPBasis2(dd_rowrange m_size,dd_colrange d_size,
       pivots_p0++;
       rank++;
     } else{
-      *found=dd_FALSE;   /* cannot pivot on any of the spacified positions. */
+      *found=dd_FALSE;   /* cannot pivot on any of the specified positions. */
       stop=dd_TRUE;
     }
     if (rank==d_size-1-negcount) {
@@ -1231,7 +1231,7 @@ void dd_FindDualFeasibleBasis(dd_rowrange m_size,dd_colrange d_size,
     }
     
     if (localdebug){
-      fprintf(stderr,"\ndd_FindDualFeasibleBasis: curruent basis is not dual feasible.\n");
+      fprintf(stderr,"\ndd_FindDualFeasibleBasis: current basis is not dual feasible.\n");
       fprintf(stderr,"because of the column %ld assoc. with var %ld   dual cost =",
        ms,nbindex[ms]);
       dd_WriteNumber(stderr, maxcost);
@@ -1413,7 +1413,7 @@ When LP is dual-inconsistent then lp->se returns the evidence column.
   dd_colrange j,s;
   static _Thread_local dd_rowindex bflag;
   static _Thread_local long mlast=0,nlast=0;
-  static _Thread_local dd_rowindex OrderVector;  /* the permutation vector to store a preordered row indeces */
+  static _Thread_local dd_rowindex OrderVector;  /* the permutation vector to store a preordered row indices */
   static _Thread_local dd_colindex nbindex_ref; /* to be used to store the initial feasible basis for lexico rule */
 
   double redpercent=0,redpercent_prev=0,redgain=0;
@@ -1595,7 +1595,7 @@ When LP is dual-inconsistent then lp->se returns the evidence column.
   dd_colrange s;
   static _Thread_local dd_rowindex bflag;
   static _Thread_local long mlast=0;
-  static _Thread_local dd_rowindex OrderVector;  /* the permutation vector to store a preordered row indeces */
+  static _Thread_local dd_rowindex OrderVector;  /* the permutation vector to store a preordered row indices */
   unsigned int rseed=1;
   dd_colindex nbtemp;
 
@@ -2221,7 +2221,7 @@ dd_LPPtr dd_CreateLP_V_ImplicitLinearity(dd_MatrixPtr M)
 
   irev=M->rowsize; /* the first row of the linc reversed inequalities. */
   for (i = 1; i <= M->rowsize; i++) {
-    dd_set(lp->A[i-1][0],dd_purezero);  /* It is almost completely degerate LP */
+    dd_set(lp->A[i-1][0],dd_purezero);  /* It is almost completely degenerate LP */
     if (set_member(i, M->linset)) {
       irev=irev+1;
       set_addelem(lp->equalityset,i);    /* it is equality. */
@@ -2323,7 +2323,7 @@ dd_LPPtr dd_CreateLP_V_Redundancy(dd_MatrixPtr M, dd_rowrange itest)
     if (i==itest){
       dd_set(lp->A[i-1][0],dd_one); /* this is to make the LP bounded, ie. the min >= -1 */
     } else {
-      dd_set(lp->A[i-1][0],dd_purezero);  /* It is almost completely degerate LP */
+      dd_set(lp->A[i-1][0],dd_purezero);  /* It is almost completely degenerate LP */
     }
     if (set_member(i, M->linset)) {
       irev=irev+1;
@@ -2374,7 +2374,7 @@ dd_LPPtr dd_CreateLP_V_SRedundancy(dd_MatrixPtr M, dd_rowrange itest)
   m=M->rowsize+1+linc+2; 
      /* We represent each equation by two inequalities.
         This is not the best way but makes the code simple.
-        Two extra constraints are for the first equation and the bouding inequality.
+        Two extra constraints are for the first equation and the bounding inequality.
         */
   d=(M->colsize)+1;  
      /* One more column.  This is different from the H-reprentation case */
@@ -2391,7 +2391,7 @@ dd_LPPtr dd_CreateLP_V_SRedundancy(dd_MatrixPtr M, dd_rowrange itest)
     if (i==itest){
       dd_set(lp->A[i-1][0],dd_purezero);  /* this is a half of the boundary constraint. */
     } else {
-      dd_set(lp->A[i-1][0],dd_purezero);  /* It is almost completely degerate LP */
+      dd_set(lp->A[i-1][0],dd_purezero);  /* It is almost completely degenerate LP */
     }
     if (set_member(i, M->linset) || i==itest) {
       irev=irev+1;
@@ -3132,7 +3132,7 @@ _L99:
 int dd_FreeOfImplicitLinearity(dd_MatrixPtr M, dd_Arow certificate, dd_rowset *imp_linrows, dd_ErrorType *error)  
   /* 092 */
 {
-  /* Checks whether the matrix M constains any implicit linearity at all.
+  /* Checks whether the matrix M contains any implicit linearity at all.
   It returns 1 if it is free of any implicit linearity.  This means that 
   the present linearity rows define the linearity correctly.  It returns
   nonpositive values otherwise.  
@@ -3295,7 +3295,7 @@ dd_rowset dd_ImplicitLinearityRows(dd_MatrixPtr M, dd_ErrorType *error)  /* 092 
 dd_boolean dd_MatrixCanonicalizeLinearity(dd_MatrixPtr *M, dd_rowset *impl_linset,dd_rowindex *newpos, 
 dd_ErrorType *error) /* 094 */
 {
-/* This is to recongnize all implicit linearities, and put all linearities at the top of
+/* This is to recognize all implicit linearities, and put all linearities at the top of
    the matrix.    All implicit linearities will be returned by *impl_linset.
 */
   dd_rowrange rank;
@@ -3392,8 +3392,8 @@ _L99:
 dd_boolean dd_ExistsRestrictedFace(dd_MatrixPtr M, dd_rowset R, dd_rowset S, dd_ErrorType *err)
 /* 0.94 */
 {
-/* This function checkes if there is a point that satifies all the constraints of
-the matrix M (interpreted as an H-representation) with additional equality contraints
+/* This function checks if there is a point that satisfies all the constraints of
+the matrix M (interpreted as an H-representation) with additional equality constraints
 specified by R and additional strict inequality constraints specified by S.
 The set S is supposed to be disjoint from both R and M->linset.   When it is not,
 the set S will be considered as S\(R U M->linset).
@@ -3426,8 +3426,8 @@ _L99:
 dd_boolean dd_ExistsRestrictedFace2(dd_MatrixPtr M, dd_rowset R, dd_rowset S, dd_LPSolutionPtr *lps, dd_ErrorType *err)
 /* 0.94 */
 {
-/* This function checkes if there is a point that satifies all the constraints of
-the matrix M (interpreted as an H-representation) with additional equality contraints
+/* This function checks if there is a point that satisfies all the constraints of
+the matrix M (interpreted as an H-representation) with additional equality constraints
 specified by R and additional strict inequality constraints specified by S.
 The set S is supposed to be disjoint from both R and M->linset.   When it is not,
 the set S will be considered as S\(R U M->linset).
@@ -3465,7 +3465,7 @@ dd_boolean dd_FindRelativeInterior(dd_MatrixPtr M, dd_rowset *ImL, dd_rowset *Lb
 /* 0.94 */
 {
 /* This function computes a point in the relative interior of the H-polyhedron given by M.
-Even the representation is V-representation, it simply interprete M as H-representation.
+Even the representation is V-representation, it simply interpret M as H-representation.
 lps returns the result of solving an LP whose solution is a relative interior point.
 ImL returns all row indices of M that are implicit linearities, i.e. their inqualities
 are satisfied by equality by all points in the polyhedron.  Lbasis returns a row basis
@@ -3682,7 +3682,7 @@ arithmetics.
     }
 
        goto _L99;
-     /* No speficied LP basis is found. */
+     /* No specified LP basis is found. */
   }
 
   if (localdebug) {

--- a/src/allfaces.c
+++ b/src/allfaces.c
@@ -67,7 +67,7 @@ dd_boolean FaceEnum(dd_MatrixPtr M, dd_rowset R, dd_rowset S, dd_boolean rip, dd
   set_initialize(&LL, M->rowsize);
   set_initialize(&RR, M->rowsize);
   set_initialize(&SS, M->rowsize);
-  set_copy(LL, M->linset); /* rememer the linset. */
+  set_copy(LL, M->linset); /* remember the linset. */
   set_copy(RR, R); /* copy of R. */
   set_copy(SS, S); /* copy of S. */
   if (dd_ExistsRestrictedFace(M, R, S, &err)){

--- a/src/cddexec.c
+++ b/src/cddexec.c
@@ -180,7 +180,7 @@ void compute_redundancy(dd_MatrixPtr M,
     fprintf(stdout, "\n");
 
     fprintf(stdout, "Nonredundant representation:\n");
-    fprintf(stdout, "The new row positions are as follows (orig:new).\nEach redundant row has the new number 0.\nEach deleted duplicated row has a number nagative of the row that\nrepresents its equivalence class.\n");
+    fprintf(stdout, "The new row positions are as follows (orig:new).\nEach redundant row has the new number 0.\nEach deleted duplicated row has a number negative of the row that\nrepresents its equivalence class.\n");
 
     for (i=1; i<=m; i++){
         fprintf(stdout, " %ld:%ld",i, newpos[i]);

--- a/src/fourier.c
+++ b/src/fourier.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
   d=M->colsize;
   M2=dd_CopyMatrix(M);
 
-  printf("How many variables to elminate? (max %ld): ",d-1);
+  printf("How many variables to eliminate? (max %ld): ",d-1);
   scanf("%ld",&s);
   
   if (s>0 && s < d){

--- a/src/projection.c
+++ b/src/projection.c
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
   d=M->colsize;
   set_initialize(&delset, d);
 
-  printf("How many variables to elminate? (max %ld): ",d-1);
+  printf("How many variables to eliminate? (max %ld): ",d-1);
   scanf("%ld",&s);
 
   for (j=1; j<=s; j++){

--- a/src/redcheck.c
+++ b/src/redcheck.c
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
   fprintf(stdout, "\n");
   
   fprintf(stdout, "Nonredundant representation:\n");
-  fprintf(stdout, "The new row positions are as follows (orig:new).\nEach redundant row has the new number 0.\nEach deleted duplicated row has a number nagative of the row that\nrepresents its equivalence class.\n");
+  fprintf(stdout, "The new row positions are as follows (orig:new).\nEach redundant row has the new number 0.\nEach deleted duplicated row has a number negative of the row that\nrepresents its equivalence class.\n");
   
   for (i=1; i<=m; i++){
    fprintf(stdout, " %ld:%ld",i, newpos[i]); 

--- a/src/testlp3.c
+++ b/src/testlp3.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
 /*  dd_WriteLPResult(writing, lp, err); */
 
 /* One can access the solutions by loading them.  See dd_WriteLPResult
-   for outputing the results correctly. */
+   for outputting the results correctly. */
   lps=dd_CopyLPSolution(lp);
   if (lps->LPS==dd_Optimal){
     printf("Optimal solution found:\n");


### PR DESCRIPTION
This is just fixing a bunch of typos, found using

```codespell -L=nd,parma,hrough,aray,tempray,statics,numbred .```

I think that this does not deserve to add something to the news.