### PR TITLE
Code hygiene/tidy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,14 @@ esac
 dnl Add -std:c11 flag for MSVC
 case $host_os in
     *cygwin*|*mingw*)
-    AX_CHECK_COMPILE_FLAG([-std:c11], [AX_APPEND_FLAG([-std:c11])])
+    AC_MSG_CHECKING([whether $CC supports -std:c11])
+    cddlib_save_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS -std:c11"
+    AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM([], [])],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_RESULT([no])
+       CFLAGS="$cddlib_save_CFLAGS"])
 ;;
 esac
 

--- a/lib-src/cdd.h
+++ b/lib-src/cdd.h
@@ -134,7 +134,6 @@ dd_MatrixPtr dd_MatrixAppend(dd_MatrixPtr M1, dd_MatrixPtr M2);  /* a name for d
 dd_MatrixPtr dd_AppendMatrix(dd_MatrixPtr M1, dd_MatrixPtr M2);  /* 090c, kept for compatibility */
 
 int dd_MatrixAppendTo(dd_MatrixPtr* M1, dd_MatrixPtr M2);  /* 092 */
-int dd_Remove(dd_MatrixPtr*, dd_rowrange);  /* 092 */
 dd_MatrixPtr dd_MatrixSubmatrix(dd_MatrixPtr M, dd_rowset delset); /* 092 */
 dd_MatrixPtr dd_MatrixSubmatrix2(dd_MatrixPtr M, dd_rowset delset,dd_rowindex* newpos); /* 094.  It returns new row positions. */
 dd_MatrixPtr dd_MatrixSubmatrix2L(dd_MatrixPtr M, dd_rowset delset,dd_rowindex* newpos); /* 094.  Linearity shifted up. */

--- a/lib-src/cddio.c
+++ b/lib-src/cddio.c
@@ -2027,4 +2027,3 @@ void dd_fread_rational_value (FILE *f, mytype value)
 
 
 /* end of cddio.c */
-

--- a/lib-src/cddmp.h
+++ b/lib-src/cddmp.h
@@ -99,23 +99,27 @@
 extern "C" {
 #endif
 
-void ddd_mpq_set_si(mytype a,signed long b);
-void ddd_init(mytype a);  
+#if defined GMPRATIONAL
+void ddd_mpq_set_si(mytype a, signed long b);
+#endif
+
+#if defined dd_CDOUBLE
+void ddd_init(mytype a);
 void ddd_clear(mytype a);
-void ddd_set(mytype a,mytype b);
-void ddd_set_d(mytype a,double b);
-void ddd_set_si(mytype a,signed long b);
-void ddd_set_si2(mytype a,signed long b, unsigned long c);
-void ddd_add(mytype a,mytype b,mytype c);
-void ddd_sub(mytype a,mytype b,mytype c);
-void ddd_mul(mytype a,mytype b,mytype c);
-void ddd_div(mytype a,mytype b,mytype c);
-void ddd_neg(mytype a,mytype b);
-void ddd_inv(mytype a,mytype b);
-int ddd_cmp(mytype a,mytype b);
+void ddd_set(mytype a, mytype b);
+void ddd_set_d(mytype a, double b);
+void ddd_set_si(mytype a, signed long b);
+void ddd_set_si2(mytype a, signed long b, unsigned long c);
+void ddd_add(mytype a, mytype b, mytype c);
+void ddd_sub(mytype a, mytype b, mytype c);
+void ddd_mul(mytype a, mytype b, mytype c);
+void ddd_div(mytype a, mytype b, mytype c);
+void ddd_neg(mytype a, mytype b);
+void ddd_inv(mytype a, mytype b);
+int ddd_cmp(mytype a, mytype b);
 int ddd_sgn(mytype a);
 double ddd_get_d(mytype a);
-void ddd_mpq_set_si(mytype a,signed long b);
+#endif
 
 void dd_set_global_constants(void);
 void dd_free_global_constants(void);  /* 094d */

--- a/news/tidy.rst
+++ b/news/tidy.rst
@@ -1,0 +1,9 @@
+**Removed:**
+
+* Remove the stale `dd_Remove` declaration; use `dd_MatrixRowRemove`.
+
+**Fixed:**
+
+* Make `./bootstrap` and `./configure` work without autoconf-archive (AX_*) macros.
+* Fix out-of-tree builds so generated GMP headers are found during compilation.
+* Only declare `ddd_*` helpers in `cddmp.h` for backends that implement them.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,6 @@ redundancies \
 redundancies_clarkson
 
 LDADD = ../lib-src/libcdd.la
-AM_CPPFLAGS = -I$(top_srcdir)/lib-src
+AM_CPPFLAGS = -I$(top_builddir)/lib-src -I$(top_srcdir)/lib-src
 
 include ./Makefile.gmp.am


### PR DESCRIPTION
**Removed:**

* Remove the stale `dd_Remove` declaration; use `dd_MatrixRowRemove`.

**Fixed:**

* Make `./bootstrap` and `./configure` work without autoconf-archive (AX_*) macros.
* Fix out-of-tree builds so generated GMP headers are found during compilation.
* Only declare `ddd_*` helpers in `cddmp.h` for backends that implement them.